### PR TITLE
Ew 44489 Migrate basic page Content type.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "drupal/link_attributes": "^1.11",
         "drupal/linkchecker": "^2.0@alpha",
         "drupal/linkit": "6.0.x-dev@dev",
+        "drupal/media_directories": "2.1.x-dev@dev",
         "drupal/menu_block": "^1.10",
         "drupal/menu_link_attributes": "^1.3",
         "drupal/metatag": "^1.22",

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,9 @@
     "extra": {
         "enable-patching": true,
         "patches": {
+            "drupal/core": {
+                "3233527 - Include file fields in File source plugin if file_entity module is enabled": "https://git.drupalcode.org/project/drupal/-/merge_requests/1201.diff"
+            },
             "drupal/linkit": {
                 "2712951 - Linkit for Link field": "https://git.drupalcode.org/project/linkit/-/merge_requests/12.diff"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15cfde3eaed26be6d56bd57a59f34320",
+    "content-hash": "c8dc2b2898c3a38199e00ab98b200f0a",
     "packages": [
         {
             "name": "acquia/blt",
@@ -3418,6 +3418,234 @@
             }
         },
         {
+            "name": "drupal/embed",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/embed.git",
+                "reference": "8.x-1.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/embed-8.x-1.6.zip",
+                "reference": "8.x-1.6",
+                "shasum": "6d2964775c3228d122cd61904786b3640fa83045"
+            },
+            "require": {
+                "drupal/core": "^9.3 | ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.6",
+                    "datestamp": "1661298150",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cs_shadow",
+                    "homepage": "https://www.drupal.org/user/2828287"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Devin Carlson",
+                    "homepage": "https://www.drupal.org/user/290182"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Provides a framework for different types of embeds in text editors.",
+            "homepage": "https://www.drupal.org/project/embed",
+            "support": {
+                "source": "https://git.drupalcode.org/project/embed"
+            }
+        },
+        {
+            "name": "drupal/entity_browser",
+            "version": "2.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_browser.git",
+                "reference": "8.x-2.9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entity_browser-8.x-2.9.zip",
+                "reference": "8.x-2.9",
+                "shasum": "251afad80cde9fa547501a8d9de5d94b9f5bacff"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/embed": "~1.0",
+                "drupal/entity_embed": "1.x-dev",
+                "drupal/entity_reference_revisions": "1.x-dev",
+                "drupal/entityqueue": "1.x-dev",
+                "drupal/inline_entity_form": "1.x-dev",
+                "drupal/paragraphs": "1.x-dev",
+                "drupal/token": "1.x-dev"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.9",
+                    "datestamp": "1674070933",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Janez Urevc",
+                    "homepage": "https://github.com/slashrsm",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Primoz Hmeljak",
+                    "homepage": "https://github.com/primsi",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/1943336/committers",
+                    "role": "contributor"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "marcingy",
+                    "homepage": "https://www.drupal.org/user/77320"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                },
+                {
+                    "name": "Primsi",
+                    "homepage": "https://www.drupal.org/user/282629"
+                },
+                {
+                    "name": "samuel.mortenson",
+                    "homepage": "https://www.drupal.org/user/2582268"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Entity browsing and selecting component.",
+            "homepage": "http://drupal.org/project/entity_browser",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_browser",
+                "issues": "https://www.drupal.org/project/issues/entity_browser",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/entity_embed",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/entity_embed.git",
+                "reference": "f41e8a4662dfa9dfc1e7c7bd20a7173f9a231352"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10",
+                "drupal/embed": "^1.5"
+            },
+            "require-dev": {
+                "drupal/ckeditor": "^1",
+                "drupal/entity_browser": "^2.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.3+1-dev",
+                    "datestamp": "1670433797",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "cs_shadow",
+                    "homepage": "https://www.drupal.org/user/2828287"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "Devin Carlson",
+                    "homepage": "https://www.drupal.org/user/290182"
+                },
+                {
+                    "name": "Drupal Media Team",
+                    "homepage": "https://www.drupal.org/user/3260690"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                },
+                {
+                    "name": "Wim Leers",
+                    "homepage": "https://www.drupal.org/user/99777"
+                }
+            ],
+            "description": "Allows any entity to be embedded within a text area using a WYSIWYG editor.",
+            "homepage": "https://www.drupal.org/project/entity_embed",
+            "support": {
+                "source": "https://git.drupalcode.org/project/entity_embed"
+            }
+        },
+        {
             "name": "drupal/entity_reference_revisions",
             "version": "1.10.0",
             "source": {
@@ -4978,6 +5206,60 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/linkit",
                 "issues": "http://drupal.org/project/linkit"
+            }
+        },
+        {
+            "name": "drupal/media_directories",
+            "version": "dev-2.1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/media_directories.git",
+                "reference": "6fc7f3ddff51df63919508873824be3b209deec8"
+            },
+            "require": {
+                "drupal/core": ">=9.3",
+                "drupal/embed": ">=1.6",
+                "drupal/entity_browser": ">=2.8",
+                "drupal/entity_embed": ">=1.3"
+            },
+            "require-dev": {
+                "drupal/embed": "^1.6",
+                "drupal/entity_browser": "*",
+                "drupal/entity_embed": "*",
+                "drupal/media_directories_ui": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.1.x": "2.1.x-dev"
+                },
+                "drupal": {
+                    "version": "2.1.x-dev",
+                    "datestamp": "1676753929",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "rang501",
+                    "homepage": "https://www.drupal.org/user/235669"
+                },
+                {
+                    "name": "ytsurk",
+                    "homepage": "https://www.drupal.org/user/1153644"
+                }
+            ],
+            "description": "Adds a directory structure to Media entities, provides a nice UI and editor integration.",
+            "homepage": "https://www.drupal.org/project/media_directories",
+            "support": {
+                "source": "https://git.drupalcode.org/project/media_directories"
             }
         },
         {
@@ -14986,6 +15268,7 @@
         "drupal/focal_point": 15,
         "drupal/linkchecker": 15,
         "drupal/linkit": 20,
+        "drupal/media_directories": 20,
         "drupal/page_manager": 5,
         "drupal/scheduler": 5,
         "drupal/scheduler_content_moderation_integration": 10,

--- a/config/default/core.base_field_override.media.image.changed.yml
+++ b/config/default/core.base_field_override.media.image.changed.yml
@@ -1,0 +1,18 @@
+uuid: aaa88a24-4176-468f-8ff1-9c245689755d
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.changed
+field_name: changed
+entity_type: media
+bundle: image
+label: Changed
+description: 'The time the media item was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.image.created.yml
+++ b/config/default/core.base_field_override.media.image.created.yml
@@ -1,0 +1,18 @@
+uuid: 6ca3f06f-0387-4d4b-adf2-494b65a68f70
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.created
+field_name: created
+entity_type: media
+bundle: image
+label: 'Authored on'
+description: 'The time the media item was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getRequestTime'
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.image.metatag.yml
+++ b/config/default/core.base_field_override.media.image.metatag.yml
@@ -1,0 +1,18 @@
+uuid: 50b20a43-2e77-4ad9-921a-ed9565300acd
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.metatag
+field_name: metatag
+entity_type: media
+bundle: image
+label: 'Metatags (Hidden field for JSON support)'
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/config/default/core.base_field_override.media.image.name.yml
+++ b/config/default/core.base_field_override.media.image.name.yml
@@ -1,0 +1,20 @@
+uuid: d39a5841-3082-4862-9187-15ff5ac75750
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.name
+field_name: name
+entity_type: media
+bundle: image
+label: Name
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.image.path.yml
+++ b/config/default/core.base_field_override.media.image.path.yml
@@ -1,0 +1,20 @@
+uuid: 4fea893e-3734-43a6-a3df-555d30da4724
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - path
+id: media.image.path
+field_name: path
+entity_type: media
+bundle: image
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.media.image.publish_on.yml
+++ b/config/default/core.base_field_override.media.image.publish_on.yml
@@ -1,0 +1,18 @@
+uuid: 5843b6ee-62fe-4981-9ff0-85b434d8defa
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.publish_on
+field_name: publish_on
+entity_type: media
+bundle: image
+label: 'Publish on'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/default/core.base_field_override.media.image.publish_state.yml
+++ b/config/default/core.base_field_override.media.image.publish_state.yml
@@ -1,0 +1,20 @@
+uuid: e6f69ad4-bc80-447d-a14a-037e0f9e84ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - options
+id: media.image.publish_state
+field_name: publish_state
+entity_type: media
+bundle: image
+label: 'Publish state'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/core.base_field_override.media.image.status.yml
+++ b/config/default/core.base_field_override.media.image.status.yml
@@ -1,0 +1,22 @@
+uuid: 02649aec-24b3-4cf5-b9a7-7ab55bf3496a
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.status
+field_name: status
+entity_type: media
+bundle: image
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.image.thumbnail.yml
+++ b/config/default/core.base_field_override.media.image.thumbnail.yml
@@ -1,0 +1,37 @@
+uuid: 568eaedc-c29f-4e51-bc09-21d8068c9dca
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - image
+id: media.image.thumbnail
+field_name: thumbnail
+entity_type: media
+bundle: image
+label: Thumbnail
+description: 'The thumbnail of the media item.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/default/core.base_field_override.media.image.uid.yml
+++ b/config/default/core.base_field_override.media.image.uid.yml
@@ -1,0 +1,20 @@
+uuid: 3feddffe-ade3-48c3-b5f6-40b33055293f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.uid
+field_name: uid
+entity_type: media
+bundle: image
+label: 'Authored by'
+description: 'The user ID of the author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media\Entity\Media::getDefaultEntityOwner'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.image.unpublish_on.yml
+++ b/config/default/core.base_field_override.media.image.unpublish_on.yml
@@ -1,0 +1,18 @@
+uuid: 94f1913c-e3e9-4a01-bf78-0d7cc6214c39
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+id: media.image.unpublish_on
+field_name: unpublish_on
+entity_type: media
+bundle: image
+label: 'Unpublish on'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/default/core.base_field_override.media.image.unpublish_state.yml
+++ b/config/default/core.base_field_override.media.image.unpublish_state.yml
@@ -1,0 +1,20 @@
+uuid: ca563479-3c5e-4160-9c14-483fd2bc5995
+langcode: en
+status: true
+dependencies:
+  config:
+    - media.type.image
+  module:
+    - options
+id: media.image.unpublish_state
+field_name: unpublish_state
+entity_type: media
+bundle: image
+label: 'Unpublish state'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/core.base_field_override.paragraph.chart.created.yml
+++ b/config/default/core.base_field_override.paragraph.chart.created.yml
@@ -1,0 +1,18 @@
+uuid: ebdcf38a-25ef-4982-bea0-e1f8cd24883d
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.chart
+id: paragraph.chart.created
+field_name: created
+entity_type: paragraph
+bundle: chart
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.paragraph.chart.status.yml
+++ b/config/default/core.base_field_override.paragraph.chart.status.yml
@@ -1,0 +1,22 @@
+uuid: 79c99872-bf57-497c-97ce-a04b602cf17c
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.chart
+id: paragraph.chart.status
+field_name: status
+entity_type: paragraph
+bundle: chart
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.paragraph.collapsable_field.created.yml
+++ b/config/default/core.base_field_override.paragraph.collapsable_field.created.yml
@@ -1,0 +1,18 @@
+uuid: 76405f70-3c83-4746-811c-c69c5f51ae3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.collapsable_field
+id: paragraph.collapsable_field.created
+field_name: created
+entity_type: paragraph
+bundle: collapsable_field
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.paragraph.collapsable_field.status.yml
+++ b/config/default/core.base_field_override.paragraph.collapsable_field.status.yml
@@ -1,0 +1,22 @@
+uuid: 5ca54646-115f-46e6-bf4d-85bc4b6feeb5
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.collapsable_field
+id: paragraph.collapsable_field.status
+field_name: status
+entity_type: paragraph
+bundle: collapsable_field
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.paragraph.image_gallery.created.yml
+++ b/config/default/core.base_field_override.paragraph.image_gallery.created.yml
@@ -1,0 +1,18 @@
+uuid: a65dfd0c-66cc-43fc-ad4b-0fd2c8f50327
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.image_gallery
+id: paragraph.image_gallery.created
+field_name: created
+entity_type: paragraph
+bundle: image_gallery
+label: 'Authored on'
+description: 'The time that the Paragraph was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.paragraph.image_gallery.status.yml
+++ b/config/default/core.base_field_override.paragraph.image_gallery.status.yml
@@ -1,0 +1,22 @@
+uuid: f73d355d-06c8-4b0b-be5c-24a3bbdd1630
+langcode: en
+status: true
+dependencies:
+  config:
+    - paragraphs.paragraphs_type.image_gallery
+id: paragraph.image_gallery.status
+field_name: status
+entity_type: paragraph
+bundle: image_gallery
+label: Published
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.entity_form_display.media.image.media_library.yml
+++ b/config/default/core.entity_form_display.media.image.media_library.yml
@@ -14,6 +14,12 @@ targetEntityType: media
 bundle: image
 mode: media_library
 content:
+  directory:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_image_1:
     type: image_image
     weight: -50

--- a/config/default/core.entity_form_display.taxonomy_term.media_folders.default.yml
+++ b/config/default/core.entity_form_display.taxonomy_term.media_folders.default.yml
@@ -1,38 +1,24 @@
-uuid: 52a1f8f2-5e56-4783-b455-17a7febc7de1
+uuid: 2866d814-7a45-4fa1-a2b1-3b12a71d1900
 langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.image.field_media_image_1
-    - image.style.thumbnail
-    - media.type.image
+    - taxonomy.vocabulary.media_folders
   module:
     - path
-    - svg_image
-id: media.image.default
-targetEntityType: media
-bundle: image
+    - text
+id: taxonomy_term.media_folders.default
+targetEntityType: taxonomy_term
+bundle: media_folders
 mode: default
 content:
-  created:
-    type: datetime_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  directory:
-    type: options_select
-    weight: 2
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_media_image_1:
-    type: image_image
+  description:
+    type: text_textfield
     weight: 0
     region: content
     settings:
-      progress_indicator: throbber
-      preview_image_style: thumbnail
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   langcode:
     type: language_select
@@ -61,16 +47,6 @@ content:
     region: content
     settings:
       display_label: true
-    third_party_settings: {  }
-  uid:
-    type: entity_reference_autocomplete
-    weight: 5
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
     third_party_settings: {  }
 hidden:
   publish_on: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -66,6 +66,7 @@ module:
   locale: 0
   maxlength: 0
   media: 0
+  media_directories: 0
   media_library: 0
   menu_block: 0
   menu_link_attributes: 0

--- a/config/default/language.content_settings.content_moderation_state.content_moderation_state.yml
+++ b/config/default/language.content_settings.content_moderation_state.content_moderation_state.yml
@@ -1,0 +1,11 @@
+uuid: d738aae0-fab0-49ba-aa76-fb9ef8267496
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_moderation
+id: content_moderation_state.content_moderation_state
+target_entity_type_id: content_moderation_state
+target_bundle: content_moderation_state
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.file.file.yml
+++ b/config/default/language.content_settings.file.file.yml
@@ -1,0 +1,11 @@
+uuid: 6a791e3c-940d-4b06-80aa-7955a928373f
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.file
+target_entity_type_id: file
+target_bundle: file
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.image.yml
+++ b/config/default/language.content_settings.media.image.yml
@@ -4,6 +4,13 @@ status: true
 dependencies:
   config:
     - media.type.image
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: media.image
 target_entity_type_id: media
 target_bundle: image

--- a/config/default/language.content_settings.paragraph.chart.yml
+++ b/config/default/language.content_settings.paragraph.chart.yml
@@ -1,18 +1,18 @@
-uuid: e18e3a39-aef6-415b-b8d4-5c5341408a69
+uuid: 3c7ed965-3cdf-49b0-bae8-2cf75b048de1
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.basic_page
+    - paragraphs.paragraphs_type.chart
   module:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: true
+    enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-id: node.basic_page
-target_entity_type_id: node
-target_bundle: basic_page
+id: paragraph.chart
+target_entity_type_id: paragraph
+target_bundle: chart
 default_langcode: site_default
 language_alterable: false

--- a/config/default/language.content_settings.paragraph.collapsable_field.yml
+++ b/config/default/language.content_settings.paragraph.collapsable_field.yml
@@ -1,18 +1,18 @@
-uuid: e18e3a39-aef6-415b-b8d4-5c5341408a69
+uuid: 6f8d758a-560a-4ad8-9bd7-d9c8985074da
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.basic_page
+    - paragraphs.paragraphs_type.collapsable_field
   module:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: true
+    enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-id: node.basic_page
-target_entity_type_id: node
-target_bundle: basic_page
+id: paragraph.collapsable_field
+target_entity_type_id: paragraph
+target_bundle: collapsable_field
 default_langcode: site_default
 language_alterable: false

--- a/config/default/language.content_settings.paragraph.image_gallery.yml
+++ b/config/default/language.content_settings.paragraph.image_gallery.yml
@@ -1,18 +1,18 @@
-uuid: e18e3a39-aef6-415b-b8d4-5c5341408a69
+uuid: 6622671f-d2fb-4f36-907e-7c9e2ac295bc
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.basic_page
+    - paragraphs.paragraphs_type.image_gallery
   module:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: true
+    enabled: false
     bundle_settings:
       untranslatable_fields_hide: '0'
-id: node.basic_page
-target_entity_type_id: node
-target_bundle: basic_page
+id: paragraph.image_gallery
+target_entity_type_id: paragraph
+target_bundle: image_gallery
 default_langcode: site_default
 language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.media_folders.yml
+++ b/config/default/language.content_settings.taxonomy_term.media_folders.yml
@@ -1,0 +1,11 @@
+uuid: aed6f0b6-b7b4-410d-a96d-54bb21faeff4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders
+target_entity_type_id: taxonomy_term
+target_bundle: media_folders
+default_langcode: site_default
+language_alterable: false

--- a/config/default/media_directories.settings.yml
+++ b/config/default/media_directories.settings.yml
@@ -1,0 +1,4 @@
+_core:
+  default_config_hash: aipPq6CU2rqYYGujJSSE_kf2CLN0BEfpxkJwt2KjJPc
+directory_taxonomy: media_folders
+all_files_in_root: true

--- a/config/default/taxonomy.vocabulary.media_folders.yml
+++ b/config/default/taxonomy.vocabulary.media_folders.yml
@@ -1,0 +1,24 @@
+uuid: a91821ae-6bf1-4bbd-9425-9bc0fb836539
+langcode: en
+status: true
+dependencies:
+  module:
+    - scheduler
+third_party_settings:
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    show_message_after_update: true
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: 'Media Folders'
+vid: media_folders
+description: 'Use media folders to organize your media'
+weight: 0

--- a/config/default/views.view.media.yml
+++ b/config/default/views.view.media.yml
@@ -6,6 +6,7 @@ dependencies:
     - image.style.thumbnail
   module:
     - media
+    - media_directories
     - svg_image
     - user
 _core:
@@ -578,6 +579,36 @@ display:
           granularity: second
       arguments: {  }
       filters:
+        directory:
+          id: directory
+          table: media_field_data
+          field: directory
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: directory
+          plugin_id: media_directory
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: directory_op
+            label: Directory
+            description: ''
+            use_operator: false
+            operator: directory_op
+            identifier: directory
+            required: false
+            remember: false
+            multiple: false
+            remember_roles: {  }
+            reduce: false
+          is_grouped: false
+          group_info: {  }
+          reduce_duplicates: false
+          error_message: true
         name:
           id: name
           table: media_field_data

--- a/config/default/views.view.media_library.yml
+++ b/config/default/views.view.media_library.yml
@@ -7,6 +7,7 @@ dependencies:
     - image.style.media_library
   module:
     - media
+    - media_directories
     - media_library
     - svg_image
     - user
@@ -230,6 +231,36 @@ display:
             field_identifier: name_1
           exposed: true
       filters:
+        directory:
+          id: directory
+          table: media_field_data
+          field: directory
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: directory
+          plugin_id: media_directory
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: directory_op
+            label: Directory
+            description: ''
+            use_operator: false
+            operator: directory_op
+            identifier: directory
+            required: false
+            remember: false
+            multiple: false
+            remember_roles: {  }
+            reduce: false
+          is_grouped: false
+          group_info: {  }
+          reduce_duplicates: false
+          error_message: true
         status:
           id: status
           table: media_field_data
@@ -478,13 +509,18 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.icon.default'
+        - 'config:core.entity_view_display.media.icon.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
   page:
     id: page
     display_title: Page
@@ -781,7 +817,11 @@ display:
         - 'url.query_args:sort_by'
         - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.icon.default'
+        - 'config:core.entity_view_display.media.icon.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
   widget:
     id: widget
     display_title: Widget
@@ -937,6 +977,36 @@ display:
           transform_dash: false
           break_phrase: false
       filters:
+        directory:
+          id: directory
+          table: media_field_data
+          field: directory
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: directory
+          plugin_id: media_directory
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: directory_op
+            label: Directory
+            description: ''
+            use_operator: false
+            operator: directory_op
+            identifier: directory
+            required: false
+            remember: false
+            multiple: false
+            remember_roles: {  }
+            reduce: false
+          is_grouped: false
+          group_info: {  }
+          reduce_duplicates: false
+          error_message: true
         status:
           id: status
           table: media_field_data
@@ -1100,8 +1170,13 @@ display:
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:core.entity_view_display.media.icon.default'
+        - 'config:core.entity_view_display.media.icon.media_library'
+        - 'config:core.entity_view_display.media.image.default'
+        - 'config:core.entity_view_display.media.image.media_library'
   widget_table:
     id: widget_table
     display_title: 'Widget (table)'
@@ -1219,6 +1294,36 @@ display:
           transform_dash: false
           break_phrase: false
       filters:
+        directory:
+          id: directory
+          table: media_field_data
+          field: directory
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: directory
+          plugin_id: media_directory
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: directory_op
+            label: Directory
+            description: ''
+            use_operator: false
+            operator: directory_op
+            identifier: directory
+            required: false
+            remember: false
+            multiple: false
+            remember_roles: {  }
+            reduce: false
+          is_grouped: false
+          group_info: {  }
+          reduce_duplicates: false
+          error_message: true
         status:
           id: status
           table: media_field_data
@@ -1390,5 +1495,6 @@ display:
         - url
         - url.query_args
         - 'url.query_args:sort_by'
+        - user
         - user.permissions
       tags: {  }

--- a/config/default/workflows.workflow.content.yml
+++ b/config/default/workflows.workflow.content.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - node.type.basic_page
     - node.type.in_page_alert
   module:
     - content_moderation
@@ -91,5 +92,6 @@ type_settings:
       weight: 5
   entity_types:
     node:
+      - basic_page
       - in_page_alert
   default_moderation_state: draft

--- a/docroot/modules/custom/yukon_migrate/migrations/media/yukon_migrate_images.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/media/yukon_migrate_images.yml
@@ -4,34 +4,48 @@ audit: true
 migration_tags:
   - Drupal 7
   - Content
+  - Media
 migration_group: legacy
 source:
   plugin: d7_file
   scheme: public
+  file_type:
+    - image
+    - wysiwyg_image
+  batch_size: 200
   constants:
     source_base_path: 'https://yukon.ca/'
 process:
-  filename: filename
-  source_full_path:
-    -
-      plugin: concat
-      delimiter: /
-      source:
-        - constants/source_base_path
-        - filepath
-    -
-      plugin: urlencode
-  uri:
-    plugin: file_copy
-    source:
-      - '@source_full_path'
-      - uri
+  name: filename
+  field_media_image_1/target_id:
+    - plugin: migration_lookup
+      migration: yukon_migrate_files__public
+      source: fid
+      no_stub: true
+    - plugin: skip_on_empty
+      method: row
+  field_media_image_1/alt: field_file_image_alt_text/0/value
+  field_media_image_1/title: field_file_image_title_text/0/value
+
+  directory:
+    plugin: migration_lookup
+    migration: yukon_migrate_media_folders
+    source: field_folder/0/tid
+    no_stub: true
+
   filemime: filemime
   status: status
   created: timestamp
   changed: timestamp
   # Todo: Replace this part with migration lookup after we migrate users.
   uid: uid
+  langcode:
+    plugin: default_value
+    default_value: "en"
 destination:
   plugin: entity:media
-  default_bundle: images
+  default_bundle: image
+#migration_dependencies:
+#  required:
+#    - yukon_migrate_files__public
+#    - yukon_migrate_media_folders

--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
@@ -73,6 +73,11 @@ process:
       migration: yukon_migrate_teams
       no_stub: true
 
+  path/alias: alias
+  path/pathauto:
+    plugin: default_value
+    default_value: false
+
 destination:
   plugin: entity:node
   default_bundle: basic_page

--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
@@ -30,25 +30,23 @@ process:
   body/format: constants/default_text_format
 
   pseudo_field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: field_collapsable_field/0/value
-    - plugin: migration_lookup
-      migration:
-        - yukon_migrate_collapsable_field
-        - yukon_migrate_charts
-      no_stub: true
+    plugin: sub_process
+    source: field_collapsable_field
+    process:
+      paragraph:
+        plugin: migration_lookup
+        source: value
+        migration:
+          - yukon_migrate_collapsable_field
+          - yukon_migrate_charts
+        no_stub: true
 
   field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: '@pseudo_field_paragraphs'
-    - plugin: sub_process
-      source:
-        - '@pseudo_field_paragraphs'
-      process:
-        target_id: '0'
-        target_revision_id: '1'
+    plugin: sub_process
+    source: '@pseudo_field_paragraphs'
+    process:
+      target_id: 'paragraph/0'
+      target_revision_id: 'paragraph/1'
 
   field_contact/value: field_contact/0/value
   field_contact/format: constants/default_text_format
@@ -57,9 +55,23 @@ process:
 
   field_page_description: field_page_description
 
-  field_related_tasks: field_related_tasks
+  field_related_tasks:
+    plugin: yukon_migrate_links
+    source: field_related_tasks
 
   field_social_sharing: field_social_sharing
+
+  field_department:
+    - plugin: migration_lookup
+      source: field_node_department
+      migration: yukon_migrate_department
+      no_stub: true
+
+  field_yukon_editorial_team:
+    - plugin: migration_lookup
+      source: field_yukon_editorial_team
+      migration: yukon_migrate_teams
+      no_stub: true
 
 destination:
   plugin: entity:node
@@ -68,3 +80,5 @@ migration_dependencies:
   optional:
     - yukon_migrate_collapsable_field
     - yukon_migrate_charts
+    - yukon_migrate_department
+    - yukon_migrate_teams

--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page_translations.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page_translations.yml
@@ -64,9 +64,23 @@ process:
 
   field_page_description: field_page_description
 
-  field_related_tasks: field_related_tasks
+  field_related_tasks:
+    plugin: yukon_migrate_links
+    source: field_related_tasks
 
   field_social_sharing: field_social_sharing
+
+  field_department:
+    - plugin: migration_lookup
+      source: field_node_department
+      migration: yukon_migrate_department
+      no_stub: true
+
+  field_yukon_editorial_team:
+    - plugin: migration_lookup
+      source: field_node_department
+      migration: yukon_migrate_department
+      no_stub: true
 
 destination:
   plugin: entity:node

--- a/docroot/modules/custom/yukon_migrate/migrations/taxonomies/yukon_migrate_media_folders.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/taxonomies/yukon_migrate_media_folders.yml
@@ -1,0 +1,33 @@
+id: yukon_migrate_media_folders
+label: Media Folders taxonomy terms
+migration_group: legacy
+migration_tags:
+  - Drupal 7
+  - taxonomy
+
+source:
+  plugin: yukon_term
+  bundle: media_folders
+  translation: false
+
+process:
+  language: language
+  name: name
+  description: description
+  weight: weight
+  parent:
+    -
+      plugin: skip_on_empty
+      source: parent
+      method: process
+    -
+      plugin: migration_lookup
+      migration: yukon_migrate_media_folders
+  path/alias: alias
+  path/pathauto:
+    plugin: default_value
+    default_value: false
+
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: media_folders

--- a/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
@@ -4,10 +4,12 @@ audit: true
 migration_tags:
   - Drupal 7
   - Content
+  - Files
 migration_group: legacy
 source:
   plugin: d7_file
   scheme: public
+  batch_size: 200
   constants:
     source_base_path: 'https://yukon.ca/'
 process:

--- a/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/process/Links.php
+++ b/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/process/Links.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\yukon_migrate\Plugin\migrate\process;
+
+use Drupal\Component\Utility\UrlHelper;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\MigrateLookupInterface;
+use Drupal\migrate\MigrateStubInterface;
+use Drupal\migrate\Plugin\migrate\process\MigrationLookup;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\Row;
+
+/**
+ * Provides a yukon_migrate_links plugin.
+ *
+ * Usage:
+ *
+ * @code
+ * process:
+ *   bar:
+ *     plugin: yukon_migrate_links
+ *     source: foo
+ * @endcode
+ *
+ * @MigrateProcessPlugin(
+ *   id = "yukon_migrate_links"
+ * )
+ *
+ * @DCG
+ * ContainerFactoryPluginInterface is optional here. If you have no need for
+ * external services just remove it and all other stuff except transform()
+ * method.
+ */
+class Links extends MigrationLookup {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, MigrateLookupInterface $migrate_lookup, MigrateStubInterface $migrate_stub) {
+    $configuration['migration'] = [
+      'yukon_migrate_basic_page',
+    ];
+    $configuration['no_stub'] = TRUE;
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $migration, $migrate_lookup, $migrate_stub);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $attributes = unserialize($value['attributes']);
+    // Drupal 6/7 link attributes might be double serialized.
+    if (!is_array($attributes)) {
+      $attributes = unserialize($attributes);
+    }
+
+    // In rare cases Drupal 6/7 link attributes are triple serialized. To avoid
+    // further problems with them we set them to an empty array in this case.
+    if (!is_array($attributes)) {
+      $attributes = [];
+    }
+
+    // Massage the values into the correct form for the link.
+    $uri = $value['url'];
+    if (!UrlHelper::isExternal($uri) && preg_match('/node\/(\d+)/', $uri, $matches)) {
+      $source_nid = $matches[1];
+
+      $destination_id = parent::transform($source_nid, $migrate_executable, $row, $destination_property);
+      if (!empty($destination_id)) {
+        $uri = "internal:/node/{$destination_id}";
+      }
+    }
+
+    $route['uri'] = $uri;
+    $route['options']['attributes'] = $attributes;
+    $route['title'] = $value['title'];
+    return $route;
+  }
+
+}

--- a/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/source/YukonFile.php
+++ b/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/source/YukonFile.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\yukon_migrate\Plugin\migrate\source;
+
+use Drupal\file\Plugin\migrate\source\d7\File;
+
+/**
+ * The 'yukon_migrate_file' source plugin.
+ *
+ * @MigrateSource(
+ *   id = "yukon_migrate_file",
+ *   source_module = "file"
+ * )
+ */
+class YukonFile extends File {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    $query = parent::query();
+    if (isset($this->configuration['file_type'])) {
+      $types = $this->configuration['file_type'];
+      if (!is_array($types)) {
+        $types = [$types];
+      }
+
+      $query->condition('type', $types);
+    }
+    return $query;
+  }
+
+}


### PR DESCRIPTION
- Added, enabled and configured the media_directories module.
- Created the Media Folders taxonomy vocabulary.
- Created migration to migrate media folders taxonomy terms.
- Added patch to the core that allows us to extract fields for the files.
- Minor updates to the files migration.
- Created custom plugin yukon_migrate_files that allows us to limit migrated file types.
- Updated the image media migration. Added alt, title and directory fields. Limited the migration to only work with images
- Updated translations configs for the paragraphs, medias, basic page content type.
- Added basic page CT to the content workflow.
- Re-worked the paragraphs field migration in the basic page migration.
- Created custom process plugin that replaces old node ids with the new one using lookup in the link field.
- Updated the link field migration in the basic page CT.
- Added department and teams fields migration to the basic page CT migration.