### PR TITLE
refs #44489: EW Basic page migration.

### DIFF
--- a/config/default/core.base_field_override.media.image.name.yml
+++ b/config/default/core.base_field_override.media.image.name.yml
@@ -11,7 +11,7 @@ bundle: image
 label: Name
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value:
   -
     value: ''

--- a/config/default/core.base_field_override.paragraph.chart.created.yml
+++ b/config/default/core.base_field_override.paragraph.chart.created.yml
@@ -1,4 +1,4 @@
-uuid: 327e73b4-5c33-405a-82e4-9bdf93fbc433
+uuid: ebdcf38a-25ef-4982-bea0-e1f8cd24883d
 langcode: en
 status: true
 dependencies:

--- a/config/default/core.base_field_override.paragraph.collapsable_field.created.yml
+++ b/config/default/core.base_field_override.paragraph.collapsable_field.created.yml
@@ -11,7 +11,7 @@ bundle: collapsable_field
 label: 'Authored on'
 description: 'The time that the Paragraph was created.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.paragraph.collapsable_field.status.yml
+++ b/config/default/core.base_field_override.paragraph.collapsable_field.status.yml
@@ -11,7 +11,7 @@ bundle: collapsable_field
 label: Published
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 1

--- a/config/default/core.base_field_override.paragraph.image_gallery.created.yml
+++ b/config/default/core.base_field_override.paragraph.image_gallery.created.yml
@@ -11,7 +11,7 @@ bundle: image_gallery
 label: 'Authored on'
 description: 'The time that the Paragraph was created.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.paragraph.image_gallery.status.yml
+++ b/config/default/core.base_field_override.paragraph.image_gallery.status.yml
@@ -11,7 +11,7 @@ bundle: image_gallery
 label: Published
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 1

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.changed.yml
@@ -1,0 +1,18 @@
+uuid: 14ebe4cd-3ccc-4c1a-8abe-301eb0a52d11
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: media_folders
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.description.yml
@@ -1,0 +1,20 @@
+uuid: 3b5b59c0-d7f7-4eeb-beba-323ee76f261a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+  module:
+    - text
+id: taxonomy_term.media_folders.description
+field_name: description
+entity_type: taxonomy_term
+bundle: media_folders
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.metatag.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.metatag.yml
@@ -1,0 +1,18 @@
+uuid: 26fafb9c-8cbc-419f-bf6a-f2243b893a63
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.metatag
+field_name: metatag
+entity_type: taxonomy_term
+bundle: media_folders
+label: 'Metatags (Hidden field for JSON support)'
+description: 'The meta tags for the entity.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: map

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.name.yml
@@ -1,0 +1,18 @@
+uuid: 4bf70454-fbc4-4a27-9138-8492cd8334ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.name
+field_name: name
+entity_type: taxonomy_term
+bundle: media_folders
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.path.yml
@@ -1,0 +1,20 @@
+uuid: 86da4536-1b46-43d8-83c3-e886f54b44a2
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+  module:
+    - path
+id: taxonomy_term.media_folders.path
+field_name: path
+entity_type: taxonomy_term
+bundle: media_folders
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.publish_on.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.publish_on.yml
@@ -1,0 +1,18 @@
+uuid: 3a9b5284-523e-4f47-abc7-3f4e10b1b580
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.publish_on
+field_name: publish_on
+entity_type: taxonomy_term
+bundle: media_folders
+label: 'Publish on'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.status.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.status.yml
@@ -1,17 +1,17 @@
-uuid: 79c99872-bf57-497c-97ce-a04b602cf17c
+uuid: f289c311-542d-40ba-ab01-83d3711cf6ed
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.chart
-id: paragraph.chart.status
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.status
 field_name: status
-entity_type: paragraph
-bundle: chart
+entity_type: taxonomy_term
+bundle: media_folders
 label: Published
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 1

--- a/config/default/core.base_field_override.taxonomy_term.media_folders.unpublish_on.yml
+++ b/config/default/core.base_field_override.taxonomy_term.media_folders.unpublish_on.yml
@@ -1,0 +1,18 @@
+uuid: 42a5d5bf-2ef3-40eb-bcbc-6daf8a93e1f8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.media_folders
+id: taxonomy_term.media_folders.unpublish_on
+field_name: unpublish_on
+entity_type: taxonomy_term
+bundle: media_folders
+label: 'Unpublish on'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: timestamp

--- a/config/default/core.entity_form_display.node.basic_page.default.yml
+++ b/config/default/core.entity_form_display.node.basic_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.basic_page.body
+    - field.field.node.basic_page.field_collapsible_items
     - field.field.node.basic_page.field_contact
     - field.field.node.basic_page.field_department
     - field.field.node.basic_page.field_full_width
@@ -11,12 +12,13 @@ dependencies:
     - field.field.node.basic_page.field_image_gallery
     - field.field.node.basic_page.field_meta_tags
     - field.field.node.basic_page.field_page_description
-    - field.field.node.basic_page.field_paragraphs
     - field.field.node.basic_page.field_related_tasks
     - field.field.node.basic_page.field_social_sharing
     - field.field.node.basic_page.field_yukon_editorial_team
     - node.type.basic_page
+    - workflows.workflow.content
   module:
+    - content_moderation
     - linkit
     - maxlength
     - media_library
@@ -44,6 +46,24 @@ content:
     weight: 5
     region: content
     settings: {  }
+    third_party_settings: {  }
+  field_collapsible_items:
+    type: paragraphs
+    weight: 101
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
     third_party_settings: {  }
   field_contact:
     type: text_textarea
@@ -112,25 +132,6 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-  field_paragraphs:
-    type: paragraphs
-    weight: 21
-    region: content
-    settings:
-      title: Section
-      title_plural: Sections
-      edit_mode: open
-      closed_mode: summary
-      autocollapse: none
-      closed_mode_threshold: 0
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: _none
-      features:
-        add_above: '0'
-        collapse_edit_all: collapse_edit_all
-        duplicate: duplicate
-    third_party_settings: {  }
   field_related_tasks:
     type: linkit
     weight: 14
@@ -160,6 +161,12 @@ content:
     region: content
     settings:
       include_locked: true
+    third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    region: content
+    settings: {  }
     third_party_settings: {  }
   path:
     type: path

--- a/config/default/core.entity_view_display.media.image.default.yml
+++ b/config/default/core.entity_view_display.media.image.default.yml
@@ -19,12 +19,12 @@ content:
     settings:
       image_link: ''
       image_style: large
+      image_loading:
+        attribute: lazy
       svg_attributes:
         width: null
         height: null
       svg_render_as_image: true
-      image_loading:
-        attribute: lazy
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/default/core.entity_view_display.media.image.media_library.yml
+++ b/config/default/core.entity_view_display.media.image.media_library.yml
@@ -20,12 +20,12 @@ content:
     settings:
       image_link: ''
       image_style: medium
+      image_loading:
+        attribute: lazy
       svg_attributes:
         width: null
         height: null
       svg_render_as_image: true
-      image_loading:
-        attribute: lazy
     third_party_settings: {  }
     weight: 0
     region: content

--- a/config/default/core.entity_view_display.node.basic_page.default.yml
+++ b/config/default/core.entity_view_display.node.basic_page.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.node.basic_page.body
+    - field.field.node.basic_page.field_collapsible_items
     - field.field.node.basic_page.field_contact
     - field.field.node.basic_page.field_department
     - field.field.node.basic_page.field_full_width
@@ -11,7 +12,6 @@ dependencies:
     - field.field.node.basic_page.field_image_gallery
     - field.field.node.basic_page.field_meta_tags
     - field.field.node.basic_page.field_page_description
-    - field.field.node.basic_page.field_paragraphs
     - field.field.node.basic_page.field_related_tasks
     - field.field.node.basic_page.field_social_sharing
     - field.field.node.basic_page.field_yukon_editorial_team
@@ -41,6 +41,20 @@ content:
         fences_label_tag: none
         fences_label_classes: ''
     weight: 2
+    region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
+  field_collapsible_items:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 9
     region: content
   field_contact:
     type: text_default
@@ -76,15 +90,6 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 5
-    region: content
-  field_paragraphs:
-    type: entity_reference_revisions_entity_view
-    label: hidden
-    settings:
-      view_mode: default
-      link: ''
-    third_party_settings: {  }
-    weight: 8
     region: content
   field_related_tasks:
     type: link

--- a/config/default/core.entity_view_display.node.basic_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.basic_page.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.basic_page.body
+    - field.field.node.basic_page.field_collapsible_items
     - field.field.node.basic_page.field_contact
     - field.field.node.basic_page.field_department
     - field.field.node.basic_page.field_full_width
@@ -12,7 +13,6 @@ dependencies:
     - field.field.node.basic_page.field_image_gallery
     - field.field.node.basic_page.field_meta_tags
     - field.field.node.basic_page.field_page_description
-    - field.field.node.basic_page.field_paragraphs
     - field.field.node.basic_page.field_related_tasks
     - field.field.node.basic_page.field_social_sharing
     - field.field.node.basic_page.field_yukon_editorial_team
@@ -33,6 +33,11 @@ content:
     third_party_settings: {  }
     weight: 101
     region: content
+  content_moderation_control:
+    settings: {  }
+    third_party_settings: {  }
+    weight: -20
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -40,6 +45,7 @@ content:
     region: content
 hidden:
   addtoany: true
+  field_collapsible_items: true
   field_contact: true
   field_department: true
   field_full_width: true
@@ -47,7 +53,6 @@ hidden:
   field_image_gallery: true
   field_meta_tags: true
   field_page_description: true
-  field_paragraphs: true
   field_related_tasks: true
   field_social_sharing: true
   field_yukon_editorial_team: true

--- a/config/default/field.field.media.image.field_media_image_1.yml
+++ b/config/default/field.field.media.image.field_media_image_1.yml
@@ -6,7 +6,18 @@ dependencies:
     - field.storage.media.field_media_image_1
     - media.type.image
   module:
+    - content_translation
+    - epp
     - image
+third_party_settings:
+  epp:
+    value: ''
+    on_update: 0
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 id: media.image.field_media_image_1
 field_name: field_media_image_1
 entity_type: media
@@ -27,10 +38,10 @@ settings:
   min_resolution: ''
   alt_field: true
   alt_field_required: true
-  title_field: false
+  title_field: true
   title_field_required: false
   default_image:
-    uuid: null
+    uuid: ''
     alt: ''
     title: ''
     width: null

--- a/config/default/field.field.node.basic_page.field_collapsible_items.yml
+++ b/config/default/field.field.node.basic_page.field_collapsible_items.yml
@@ -1,9 +1,9 @@
-uuid: eb0c67fb-3bc9-43ea-8807-06fb16a20f5f
+uuid: 84805030-e6c5-46b0-a097-2f28663616d8
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_paragraphs
+    - field.storage.node.field_collapsible_items
     - node.type.basic_page
     - paragraphs.paragraphs_type.chart
     - paragraphs.paragraphs_type.collapsable_field
@@ -14,8 +14,8 @@ third_party_settings:
   epp:
     value: ''
     on_update: 0
-id: node.basic_page.field_paragraphs
-field_name: field_paragraphs
+id: node.basic_page.field_collapsible_items
+field_name: field_collapsible_items
 entity_type: node
 bundle: basic_page
 label: 'Collapsable field'

--- a/config/default/field.field.paragraph.collapsable_field.field_description.yml
+++ b/config/default/field.field.paragraph.collapsable_field.field_description.yml
@@ -14,7 +14,7 @@ bundle: collapsable_field
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.paragraph.collapsable_field.field_paragraphs.yml
+++ b/config/default/field.field.paragraph.collapsable_field.field_paragraphs.yml
@@ -20,7 +20,7 @@ bundle: collapsable_field
 label: Charts
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.paragraph.collapsable_field.field_title.yml
+++ b/config/default/field.field.paragraph.collapsable_field.field_title.yml
@@ -18,7 +18,7 @@ bundle: collapsable_field
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.paragraph.image_gallery.field_description_plain.yml
+++ b/config/default/field.field.paragraph.image_gallery.field_description_plain.yml
@@ -18,7 +18,7 @@ bundle: image_gallery
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.paragraph.image_gallery.field_image.yml
+++ b/config/default/field.field.paragraph.image_gallery.field_image.yml
@@ -16,10 +16,10 @@ id: paragraph.image_gallery.field_image
 field_name: field_image
 entity_type: paragraph
 bundle: image_gallery
-label: Image
+label: 'Slide image'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.paragraph.image_gallery.field_link.yml
+++ b/config/default/field.field.paragraph.image_gallery.field_link.yml
@@ -19,7 +19,7 @@ bundle: image_gallery
 label: Link
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.paragraph.image_gallery.field_title.yml
+++ b/config/default/field.field.paragraph.image_gallery.field_title.yml
@@ -18,7 +18,7 @@ bundle: image_gallery
 label: Title
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.storage.node.field_collapsible_items.yml
+++ b/config/default/field.storage.node.field_collapsible_items.yml
@@ -1,0 +1,21 @@
+uuid: 9a676d4d-9429-473c-9c50-2a333289f94d
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_collapsible_items
+field_name: field_collapsible_items
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/language.content_settings.media.image.yml
+++ b/config/default/language.content_settings.media.image.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: media.image
 target_entity_type_id: media
 target_bundle: image

--- a/config/default/language.content_settings.node.basic_page.yml
+++ b/config/default/language.content_settings.node.basic_page.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: node.basic_page
 target_entity_type_id: node
 target_bundle: basic_page

--- a/config/default/language.content_settings.paragraph.chart.yml
+++ b/config/default/language.content_settings.paragraph.chart.yml
@@ -1,4 +1,4 @@
-uuid: c8638798-27a6-4bfa-a4c0-bb86446d3366
+uuid: 3c7ed965-3cdf-49b0-bae8-2cf75b048de1
 langcode: en
 status: true
 dependencies:

--- a/config/default/language.content_settings.paragraph.collapsable_field.yml
+++ b/config/default/language.content_settings.paragraph.collapsable_field.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
       untranslatable_fields_hide: '0'
 id: paragraph.collapsable_field
 target_entity_type_id: paragraph
 target_bundle: collapsable_field
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.paragraph.image_gallery.yml
+++ b/config/default/language.content_settings.paragraph.image_gallery.yml
@@ -8,11 +8,11 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.image_gallery
 target_entity_type_id: paragraph
 target_bundle: image_gallery
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.taxonomy_term.media_folders.yml
+++ b/config/default/language.content_settings.taxonomy_term.media_folders.yml
@@ -4,6 +4,13 @@ status: true
 dependencies:
   config:
     - taxonomy.vocabulary.media_folders
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+    bundle_settings:
+      untranslatable_fields_hide: '0'
 id: taxonomy_term.media_folders
 target_entity_type_id: taxonomy_term
 target_bundle: media_folders

--- a/docroot/modules/custom/yukon_migrate/migrations/media/yukon_migrate_images.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/media/yukon_migrate_images.yml
@@ -45,7 +45,7 @@ process:
 destination:
   plugin: entity:media
   default_bundle: image
-#migration_dependencies:
-#  required:
+migration_dependencies:
+  required:
 #    - yukon_migrate_files__public
-#    - yukon_migrate_media_folders
+    - yukon_migrate_media_folders

--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page.yml
@@ -29,7 +29,7 @@ process:
   body/value: body/0/value
   body/format: constants/default_text_format
 
-  pseudo_field_paragraphs:
+  pseudo_field_collapsible_items:
     plugin: sub_process
     source: field_collapsable_field
     process:
@@ -41,9 +41,26 @@ process:
           - yukon_migrate_charts
         no_stub: true
 
-  field_paragraphs:
+  field_collapsible_items:
     plugin: sub_process
-    source: '@pseudo_field_paragraphs'
+    source: '@pseudo_field_collapsible_items'
+    process:
+      target_id: 'paragraph/0'
+      target_revision_id: 'paragraph/1'
+
+  pseudo_field_image_gallery:
+    plugin: sub_process
+    source: field_image_gallery
+    process:
+      paragraph:
+        plugin: migration_lookup
+        source: value
+        migration: yukon_migrate_image_gallery
+        no_stub: true
+
+  field_image_gallery:
+    plugin: sub_process
+    source: '@pseudo_field_image_gallery'
     process:
       target_id: 'paragraph/0'
       target_revision_id: 'paragraph/1'
@@ -73,6 +90,12 @@ process:
       migration: yukon_migrate_teams
       no_stub: true
 
+  field_image:
+    plugin: migration_lookup
+    source: field_featured_image/0/fid
+    migration: yukon_migrate_images
+    no_stub: true
+
   path/alias: alias
   path/pathauto:
     plugin: default_value
@@ -84,6 +107,8 @@ destination:
 migration_dependencies:
   optional:
     - yukon_migrate_collapsable_field
+    - yukon_migrate_image_gallery
     - yukon_migrate_charts
     - yukon_migrate_department
     - yukon_migrate_teams
+    - yukon_migrate_images

--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page_translations.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_basic_page_translations.yml
@@ -36,26 +36,41 @@ process:
   body/value: body/0/value
   body/format: constants/default_text_format
 
-  pseudo_field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: field_collapsable_field/0/value
-    - plugin: migration_lookup
-      migration:
-        - yukon_migrate_collapsable_field
-        - yukon_migrate_charts
-      no_stub: true
+  pseudo_field_collapsible_items:
+    plugin: sub_process
+    source: field_collapsable_field
+    process:
+      paragraph:
+        plugin: migration_lookup
+        source: value
+        migration:
+          - yukon_migrate_collapsable_field
+          - yukon_migrate_charts
+        no_stub: true
 
-  field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: '@pseudo_field_paragraphs'
-    - plugin: sub_process
-      source:
-        - '@pseudo_field_paragraphs'
-      process:
-        target_id: '0'
-        target_revision_id: '1'
+  field_collapsible_items:
+    plugin: sub_process
+    source: '@pseudo_field_collapsible_items'
+    process:
+      target_id: 'paragraph/0'
+      target_revision_id: 'paragraph/1'
+
+  pseudo_field_image_gallery:
+    plugin: sub_process
+    source: field_collapsable_field
+    process:
+      paragraph:
+        plugin: migration_lookup
+        source: value
+        migration: yukon_migrate_image_gallery
+        no_stub: true
+
+  field_image_gallery:
+    plugin: sub_process
+    source: '@pseudo_field_image_gallery'
+    process:
+      target_id: 'paragraph/0'
+      target_revision_id: 'paragraph/1'
 
   field_contact/value: field_contact/0/value
   field_contact/format: constants/default_text_format
@@ -81,6 +96,17 @@ process:
       source: field_node_department
       migration: yukon_migrate_department
       no_stub: true
+
+  field_image:
+    plugin: migration_lookup
+    source: field_featured_image/0/fid
+    migration: yukon_migrate_images
+    no_stub: true
+
+  path/alias: alias
+  path/pathauto:
+    plugin: default_value
+    default_value: false
 
 destination:
   plugin: entity:node

--- a/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_collapsable_field.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_collapsable_field.yml
@@ -17,23 +17,22 @@ process:
   field_description/format: constants/default_text_format
 
   pseudo_field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: field_charts/0/value
-    - plugin: migration_lookup
-      migration: yukon_migrate_charts
-      no_stub: true
+    plugin: sub_process
+    source: field_charts
+    process:
+      paragraph:
+        plugin: migration_lookup
+        source: value
+        migration:
+          - yukon_migrate_charts
+        no_stub: true
 
   field_paragraphs:
-    - plugin: skip_on_empty
-      method: process
-      source: '@pseudo_field_paragraphs'
-    - plugin: sub_process
-      source:
-        - '@pseudo_field_paragraphs'
-      process:
-        target_id: '0'
-        target_revision_id: '1'
+    plugin: sub_process
+    source: '@pseudo_field_paragraphs'
+    process:
+      target_id: 'paragraph/0'
+      target_revision_id: 'paragraph/1'
 
 destination:
   plugin: entity_reference_revisions:paragraph

--- a/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_image_gallery.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_image_gallery.yml
@@ -1,5 +1,5 @@
 id: yukon_migrate_image_gallery
-label: Yukon Migrate Collapsable field Paragraph
+label: Yukon Migrate Image Gallery Paragraph
 migration_tags:
   - Drupal 7
   - Content

--- a/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_image_gallery.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_image_gallery.yml
@@ -1,0 +1,33 @@
+id: yukon_migrate_image_gallery
+label: Yukon Migrate Collapsable field Paragraph
+migration_tags:
+  - Drupal 7
+  - Content
+  - Paragraphs Content
+migration_group: legacy
+source:
+  plugin: d7_paragraphs_item
+  bundle: image_gallery
+  constants:
+    default_text_format: full_html
+process:
+  field_title: title_field
+
+  field_description/value: field_description/0/value
+
+  field_link:
+    plugin: yukon_migrate_links
+    source: field_link
+
+  field_image:
+    plugin: migration_lookup
+    source: field_slide_image/0/fid
+    migration: yukon_migrate_images
+    no_stub: true
+
+destination:
+  plugin: entity_reference_revisions:paragraph
+  default_bundle: image_gallery
+migration_dependencies:
+  required:
+    - yukon_migrate_charts

--- a/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/process/Links.php
+++ b/docroot/modules/custom/yukon_migrate/src/Plugin/migrate/process/Links.php
@@ -39,6 +39,7 @@ class Links extends MigrationLookup {
   public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, MigrateLookupInterface $migrate_lookup, MigrateStubInterface $migrate_stub) {
     $configuration['migration'] = [
       'yukon_migrate_basic_page',
+      'yukon_migrate_basic_page_translations',
     ];
     $configuration['no_stub'] = TRUE;
 


### PR DESCRIPTION
- Replaced the machine name for the paragraphs field in the basic page. Updated migrations.
- Created migration for the image gallery paragraph.
- Fixed the paragraphs field migration process in the collapsible field paragraph.
- Enabled translations for the basic page paragraphs and fields.
- Added the migration rules for field_image_gallery and field_image fields in the basic page CT.
- Added the alias migration rule.
- Minor fixes.