### PR TITLE
Issue #142 - French translation does not appear

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -137,6 +137,7 @@ module:
   yukon_base: 0
   yukon_department: 0
   yukon_migrate: 0
+  yukon_w3_migrate: 0
   pathauto: 1
   content_translation: 10
   password_policy: 10

--- a/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
+++ b/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
@@ -32,7 +32,7 @@ class ImportDataController extends ControllerBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    return new static(
+    return new self(
       $container->get('messenger')
     );
   }

--- a/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
+++ b/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace Drupal\yukon_w3_migrate\Controller;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides route responses for landing-page routing.
+ */
+class ImportDataController extends ControllerBase {
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs InviteByEmail .
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(MessengerInterface $messenger) {
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Update the translation for primary links.
+   */
+  public function content() {
+
+    // For landing page.
+    $db = Database::getConnection();
+    $query = $db->select("node_field_data", "n");
+    $query->fields("n", ["nid", "title"]);
+    $query->condition("n.type", "landing_page");
+    $query->condition("n.langcode", "en");
+    $results = $query->execute()->fetchAll();
+
+    foreach ($results as $result) {
+      $query = $db->select("node__field_primary_content", "p");
+      $query->fields("p", []);
+      $query->condition("p.bundle", "landing_page");
+      $query->condition("p.entity_id", $result->nid);
+      $query->condition("p.langcode", "en");
+      $primary_cont = $query->execute()->fetchAll();
+
+      $query = $db->select("paragraphs_item_field_data", "i");
+      $query->fields("i", []);
+      $query->condition("i.type", "primary_content");
+      $query->condition(
+            "i.id",
+            $primary_cont[0]->field_primary_content_target_id
+        );
+      $query->condition("i.langcode", "fr");
+      $primary_fr = $query->execute()->fetchAll();
+
+      if (empty($primary_fr)) {
+        $query = $db->select("paragraphs_item_field_data", "i");
+        $query->fields("i", []);
+        $query->condition("i.type", "primary_content");
+        $query->condition(
+          "i.id",
+          $primary_cont[0]->field_primary_content_target_id
+          );
+        $query->condition("i.langcode", "en");
+        $primary_en = $query->execute()->fetchAll();
+
+        if (!empty($primary_en[0]->id)) {
+          $db->update("paragraphs_item_field_data")
+            ->fields([
+              "revision_translation_affected" => NULL,
+            ])
+            ->condition("id", $primary_en[0]->id, "=")
+            ->execute();
+
+          $result = $db
+            ->insert("paragraphs_item_field_data")
+            ->fields([
+              "id" => $primary_en[0]->id,
+              "revision_id" => $primary_en[0]->revision_id,
+              "type" => $primary_en[0]->type,
+              "langcode" => "fr",
+              "status" => $primary_en[0]->status,
+              "created" => $primary_en[0]->created,
+              "parent_id" => $primary_en[0]->parent_id,
+              "parent_type" => $primary_en[0]->parent_type,
+              "parent_field_name" =>
+              $primary_en[0]->parent_field_name,
+              "behavior_settings" =>
+              $primary_en[0]->behavior_settings,
+              "default_langcode" => 0,
+              "revision_translation_affected" => 1,
+              "content_translation_source" => "en",
+              "content_translation_outdated" =>
+              $primary_en[0]->content_translation_outdated,
+              "content_translation_changed" =>
+              $primary_en[0]->content_translation_changed,
+            ])
+            ->execute();
+
+          $result = $db
+            ->insert("paragraphs_item_revision_field_data")
+            ->fields([
+              "id" => $primary_en[0]->id,
+              "revision_id" => $primary_en[0]->revision_id,
+              // 'type' => $primary_en[0]->type,
+              "langcode" => "fr",
+              "status" => $primary_en[0]->status,
+              "created" => $primary_en[0]->created,
+              "parent_id" => $primary_en[0]->parent_id,
+              "parent_type" => $primary_en[0]->parent_type,
+              "parent_field_name" =>
+              $primary_en[0]->parent_field_name,
+              "behavior_settings" =>
+              $primary_en[0]->behavior_settings,
+              "default_langcode" => 0,
+              "revision_translation_affected" => 1,
+              "content_translation_source" => "en",
+              "content_translation_outdated" =>
+              $primary_en[0]->content_translation_outdated,
+              "content_translation_changed" =>
+              $primary_en[0]->content_translation_changed,
+            ])
+            ->execute();
+
+          $query = $db->select("paragraph__field_popular_links", "i");
+          $query->fields("i", []);
+          $query->condition("i.bundle", "primary_content");
+          $query->condition("i.entity_id", $primary_en[0]->id);
+          $primary_popular = $query->execute()->fetchAll();
+
+          foreach ($primary_popular as $populer) {
+            $result = $db
+              ->insert("paragraph__field_popular_links")
+              ->fields([
+                "bundle" => $populer->bundle,
+                "deleted" => $populer->deleted,
+                "entity_id" => $populer->entity_id,
+                "revision_id" => $populer->revision_id,
+                "langcode" => "fr",
+                "delta" => $populer->delta,
+                "field_popular_links_target_id" =>
+                $populer->field_popular_links_target_id,
+              ])
+              ->execute();
+
+            $result = $db
+              ->insert("paragraph_revision__field_popular_links")
+              ->fields([
+                "bundle" => $populer->bundle,
+                "deleted" => $populer->deleted,
+                "entity_id" => $populer->entity_id,
+                "revision_id" => $populer->revision_id,
+                "langcode" => "fr",
+                "delta" => $populer->delta,
+                "field_popular_links_target_id" =>
+                $populer->field_popular_links_target_id,
+              ])
+              ->execute();
+          }
+        }
+      }
+    }
+
+    // For landing page level 2.
+    $db = Database::getConnection();
+    $query = $db->select("node_field_data", "n");
+    $query->fields("n", ["nid", "title"]);
+    $query->condition("n.type", "landing_page_level_2");
+    $query->condition("n.langcode", "en");
+    $results = $query->execute()->fetchAll();
+
+    foreach ($results as $result) {
+      $query = $db->select("node__field_primary_content", "p");
+      $query->fields("p", []);
+      $query->condition("p.bundle", "landing_page_level_2");
+      $query->condition("p.entity_id", $result->nid);
+      $query->condition("p.langcode", "en");
+      $primary_cont = $query->execute()->fetchAll();
+
+      $query = $db->select("paragraphs_item_field_data", "i");
+      $query->fields("i", []);
+      $query->condition("i.type", "primary_content");
+      $query->condition(
+            "i.id",
+            $primary_cont[0]->field_primary_content_target_id
+        );
+      $query->condition("i.langcode", "fr");
+      $primary_fr = $query->execute()->fetchAll();
+
+      if (empty($primary_fr)) {
+        $query = $db->select("paragraphs_item_field_data", "i");
+        $query->fields("i", []);
+        $query->condition("i.type", "primary_content");
+        $query->condition(
+          "i.id",
+          $primary_cont[0]->field_primary_content_target_id
+          );
+        $query->condition("i.langcode", "en");
+        $primary_en = $query->execute()->fetchAll();
+
+        if (!empty($primary_en[0]->id)) {
+          $db->update("paragraphs_item_field_data")
+            ->fields([
+              "revision_translation_affected" => NULL,
+            ])
+            ->condition("id", $primary_en[0]->id, "=")
+            ->execute();
+
+          $result = $db
+            ->insert("paragraphs_item_field_data")
+            ->fields([
+              "id" => $primary_en[0]->id,
+              "revision_id" => $primary_en[0]->revision_id,
+              "type" => $primary_en[0]->type,
+              "langcode" => "fr",
+              "status" => $primary_en[0]->status,
+              "created" => $primary_en[0]->created,
+              "parent_id" => $primary_en[0]->parent_id,
+              "parent_type" => $primary_en[0]->parent_type,
+              "parent_field_name" =>
+              $primary_en[0]->parent_field_name,
+              "behavior_settings" =>
+              $primary_en[0]->behavior_settings,
+              "default_langcode" => 0,
+              "revision_translation_affected" => 1,
+              "content_translation_source" => "en",
+              "content_translation_outdated" =>
+              $primary_en[0]->content_translation_outdated,
+              "content_translation_changed" =>
+              $primary_en[0]->content_translation_changed,
+            ])
+            ->execute();
+
+          $result = $db
+            ->insert("paragraphs_item_revision_field_data")
+            ->fields([
+              "id" => $primary_en[0]->id,
+              "revision_id" => $primary_en[0]->revision_id,
+                  // 'type' => $primary_en[0]->type,
+              "langcode" => "fr",
+              "status" => $primary_en[0]->status,
+              "created" => $primary_en[0]->created,
+              "parent_id" => $primary_en[0]->parent_id,
+              "parent_type" => $primary_en[0]->parent_type,
+              "parent_field_name" =>
+              $primary_en[0]->parent_field_name,
+              "behavior_settings" =>
+              $primary_en[0]->behavior_settings,
+              "default_langcode" => 0,
+              "revision_translation_affected" => 1,
+              "content_translation_source" => "en",
+              "content_translation_outdated" =>
+              $primary_en[0]->content_translation_outdated,
+              "content_translation_changed" =>
+              $primary_en[0]->content_translation_changed,
+            ])
+            ->execute();
+
+          $query = $db->select("paragraph__field_popular_links", "i");
+          $query->fields("i", []);
+          $query->condition("i.bundle", "primary_content");
+          $query->condition("i.entity_id", $primary_en[0]->id);
+          $primary_popular = $query->execute()->fetchAll();
+
+          foreach ($primary_popular as $populer) {
+            $result = $db
+              ->insert("paragraph__field_popular_links")
+              ->fields([
+                "bundle" => $populer->bundle,
+                "deleted" => $populer->deleted,
+                "entity_id" => $populer->entity_id,
+                "revision_id" => $populer->revision_id,
+                "langcode" => "fr",
+                "delta" => $populer->delta,
+                "field_popular_links_target_id" =>
+                $populer->field_popular_links_target_id,
+              ])
+              ->execute();
+
+            $result = $db
+              ->insert("paragraph_revision__field_popular_links")
+              ->fields([
+                "bundle" => $populer->bundle,
+                "deleted" => $populer->deleted,
+                "entity_id" => $populer->entity_id,
+                "revision_id" => $populer->revision_id,
+                "langcode" => "fr",
+                "delta" => $populer->delta,
+                "field_popular_links_target_id" =>
+                $populer->field_popular_links_target_id,
+              ])
+              ->execute();
+          }
+        }
+      }
+    }
+    $this->messenger()->addMessage("Updates are successfully done");
+    return [
+      '#markup' => '<p></p>',
+    ];
+  }
+
+}

--- a/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.info.yml
+++ b/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.info.yml
@@ -1,0 +1,5 @@
+name: yukon w3 migrate
+type: module
+description: 'yukon w3 migrate'
+core_version_requirement: ^10 || ^9
+package: 'yukon'

--- a/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.permissions.yml
+++ b/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.permissions.yml
@@ -1,0 +1,4 @@
+Import form:
+  title: 'Add Import data settings Permission'
+  description: 'Permission for add import data form'
+  restrict access: true

--- a/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.routing.yml
+++ b/docroot/modules/custom/yukon_w3_migrate/yukon_w3_migrate.routing.yml
@@ -1,0 +1,7 @@
+yukon_w3_migrate.migrate:
+  path: '/custom_migrate'
+  defaults:
+    _title: 'Migrate Data'
+    _controller: '\Drupal\yukon_w3_migrate\Controller\ImportDataController::content'
+  requirements:
+    _permission: 'Import form'


### PR DESCRIPTION
**Issue Addressed:** 
https://github.com/ytgov/yukon-ca/issues/142

**Steps:**

1. Merge the PR
2. Login to Drupal admin
3. Click **Extend** on the top admin menu
4. In the **Filter** (Input Box), search **yukon w3 migrate**, check the checkbox and click **Install.**
5. After the custom module gets installed, click the link **[root-URL]/custom_migrate**. 
6. Wait for some time. When done, clear the Drupal cache using **drush cr** 

**Notes**

This is a custom module that will update the missing translations.
If the static function is not acceptable then we can try changing it. But it is used in Drupal core as well:

[Drupal Docs](https://www.drupal.org/docs/develop/development-tools/phpstan/handling-unsafe-usage-of-new-static#:~:text=If%20you%20choose%20not%20to%20make%20the%20class%20final%2C%20add%20the%20error%20to%20the%20ignored%20errors%20in%20your%20configuration.%20This%20is%20what%20Drupal%20core%20has%20done%3A)