### PR TITLE
Issue #332 - Split Data and Media Migrations

### DIFF
--- a/docroot/modules/custom/yukon_migrate/README.md
+++ b/docroot/modules/custom/yukon_migrate/README.md
@@ -1,3 +1,5 @@
 Migrations should be put in migrations.yml
 
 * Set migration_group to "legacy" to inherit the source DB settings
+
+* This is a modified version to split migration into two group. For full migration, please use the original module.

--- a/docroot/modules/custom/yukon_migrate/config/install/migrate_plus.migration_group.legacy_media.yml
+++ b/docroot/modules/custom/yukon_migrate/config/install/migrate_plus.migration_group.legacy_media.yml
@@ -1,0 +1,6 @@
+id: legacy_media
+label: Yukon.ca legacy media site
+source_type: Drupal 7
+shared_configuration:
+  migration_tags:
+    - Drupal 7

--- a/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
@@ -28,6 +28,8 @@ process:
     source:
       - '@source_full_path'
       - uri
+    file_exists: 'use existing'
+    move: false
   filemime: filemime
   status: status
   created: timestamp

--- a/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/yukon_migrate_files__public.yml
@@ -5,7 +5,7 @@ migration_tags:
   - Drupal 7
   - Content
   - Files
-migration_group: legacy
+migration_group: legacy_media
 source:
   plugin: d7_file
   scheme: public


### PR DESCRIPTION
**Steps:**

1. Create a fresh Drupal 10 installation with minimal theme.  
2. Run the following command **./vendor/bin/drush config-get "system.site" uuid**. This step will display the new UUID that can be copied and replaced in the following file at line 4: **[web-root]/config/sync/system.site.yml**
3. Run **./vendor/bin/drush cim -y** to copy config files until you see the success message for completion.
4. Copy all the media files in **[web=root]/docroot/sites/default/files**. This folder content should be the same as Drupal 7 version of Yukon.ca
5. Run media migration first using this command in terminal **./vendor/bin/drush migrate:import yukon_migrate_files__public**. This should run for around 2 hours as per the current data size.  
6. Run **./vendor/bin/drush cr** to clear the cache, if required.
7. After completing the media migration you can run the data migration using this command in terminal: **./vendor/bin/drush migrate:import --group=legacy --continue-on-failure**. This should run for around 2.5 hours as per the current data size.  

**Notes:**

1. Step 5 will skip the media files if already present in the D10 files folder.
2. This is a modified version of yukon_migrate module to split migration into two groups. For full migration, please use the original module.