### PR TITLE
Issue #151 - Topic Page description heading visible in D10

### DIFF
--- a/config/default/core.entity_view_display.node.topics_page.default.yml
+++ b/config/default/core.entity_view_display.node.topics_page.default.yml
@@ -26,7 +26,7 @@ mode: default
 content:
   body:
     type: text_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     weight: 103


### PR DESCRIPTION
**Issue Addressed:** 

[151](https://github.com/ytgov/yukon-ca/issues/151) .

**Steps:**

1. Merge the PR
2. Run the **drush cim -y** command.
3. Clear Drupal cache using **drush cr**.