### PR TITLE
Revise-Issue#142 - French translation does not appear 

### DIFF
--- a/config/default/language/fr/field.field.node.landing_page.field_primary_content.yml
+++ b/config/default/language/fr/field.field.node.landing_page.field_primary_content.yml
@@ -1,0 +1,1 @@
+label: Rubriques


### PR DESCRIPTION
**Issue Addressed:** 
https://github.com/ytgov/yukon-ca/issues/142

**Steps:**

1. Merge the PR
2. Login to Drupal admin
3. Click **Extend** on the top admin menu
4. In the **Filter** (Input Box), search **yukon w3 migrate**, check the checkbox and click **Install.**
5. After the custom module gets installed, click the link **[root-URL]/custom_migrate**. 
6. Wait for some time. When done, clear the Drupal cache using **drush cr** 

**Notes**

This is a custom module that will update the missing translations.
