### PR TITLE
Issue#186 - News should support multiple Quick facts

### DIFF
--- a/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_quick_facts.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_quick_facts.yml
@@ -15,8 +15,7 @@ process:
   langcode:
     plugin: default_value
     default_value: "en"
-  field_facts/value: field_facts/0/value
-  field_facts/format: constants/default_text_format
+  field_facts: field_facts
 
 destination:
   plugin: entity_reference_revisions:paragraph

--- a/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_quick_facts_translations.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/paragraphs/yukon_migrate_quick_facts_translations.yml
@@ -14,8 +14,8 @@ process:
   langcode:
     plugin: default_value
     default_value: "fr"
-  field_facts/value: field_facts/0/value
-  field_facts/format: constants/default_text_format
+  field_facts: field_facts
+
 destination:
   plugin: entity_reference_revisions:paragraph
   default_bundle: quick_facts

--- a/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
+++ b/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
@@ -42,13 +42,13 @@ class ImportDataController extends ControllerBase {
    */
   public function content() {
     $db = Database::getConnection();
-    // Update format of the quick facts
+    // Update format of the quick facts.
     $db->update("paragraph__field_facts")
-        ->fields([
-          "field_facts_format" => "full_html",
-        ])
-        ->execute();
-    
+      ->fields([
+        "field_facts_format" => "full_html",
+      ])
+      ->execute();
+
     // For landing page.
     $query = $db->select("node_field_data", "n");
     $query->fields("n", ["nid", "title"]);

--- a/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
+++ b/docroot/modules/custom/yukon_w3_migrate/src/Controller/ImportDataController.php
@@ -41,9 +41,15 @@ class ImportDataController extends ControllerBase {
    * Update the translation for primary links.
    */
   public function content() {
-
-    // For landing page.
     $db = Database::getConnection();
+    // Update format of the quick facts
+    $db->update("paragraph__field_facts")
+        ->fields([
+          "field_facts_format" => "full_html",
+        ])
+        ->execute();
+    
+    // For landing page.
     $query = $db->select("node_field_data", "n");
     $query->fields("n", ["nid", "title"]);
     $query->condition("n.type", "landing_page");


### PR DESCRIPTION
**Issue Addressed:**
https://github.com/ytgov/yukon-ca/issues/186

**Steps:**

1. Merge the PR
2. Re-run migration update
3. Login to Drupal admin
4. Click Extend on the top admin menu
5. In the Filter (Input Box), search yukon w3 migrate, check the checkbox and click Install.
6. After the custom module gets installed, click the link [root-URL]/custom_migrate.
7. Wait for some time. When done, clear the Drupal cache using drush cr

**Notes**
This is a custom module that will update the missing translations.