### PR TITLE
Core patch to fix error on config import

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
+                "2321071 - BaseFieldOverride fails to take into account ContentEntityInterface::bundleFieldDefinitions() when invoking onFieldDefinitionUpdate()": "https://www.drupal.org/files/issues/2019-12-24/2321071-39.patch",
                 "3233527 - Include file fields in File source plugin if file_entity module is enabled": "https://www.drupal.org/files/issues/2022-04-04/drupal_core-3233527-Include-file-fields-in-File-source-plugin-if-file_entity-module-is-enabled.patch",
                 "3154156 - Improve migration system performance: statically cache DrupalSqlBase::$systemData": "https://www.drupal.org/files/issues/2020-06-23/3154156-2.patch",
                 "3115445 - Add a new clean_unique_id Twig filter for Html::getUniqueId": "https://www.drupal.org/files/issues/2021-05-14/3115445-10-reroll.patch",


### PR DESCRIPTION
Applies patch from [2321071:BaseFieldOverride fails to take into account ContentEntityInterface::bundleFieldDefinitions() when invoking onFieldDefinitionUpdate()](https://www.drupal.org/node/2321071)

The error is:

>  [error]  TypeError: Drupal\Core\Entity\ContentEntityStorageBase::onFieldDefinitionUpdate(): Argument #2 ($original) must be of type Drupal\Core\Field\FieldDefinitionInterface, null given, called in /var/www/docroot/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php on line 210 in Drupal\Core\Entity\ContentEntityStorageBase->onFieldDefinitionUpdate() (line 546 of /var/www/docroot/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php) #0 /var/www/docroot/core/lib/Drupal/Core/Field/Entity/BaseFieldOverride.php(210): Drupal\Core\Entity\ContentEntityStorageBase->onFieldDefinitionUpdate(Object(Drupal\Core\Field\Entity\BaseFieldOverride), NULL)

With this patch, `config import` still fails once, but subsequent runs do complete.