### PR TITLE
Scripts to standardize data migration process

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,55 +69,44 @@ There are more than 30K nodes on the D7 version and it can take anywhere between
 
 Running the following 10 commands will import the data from Drupal 7 to Druapl 10. Please note that this is the start of migration where Drupal 10 has no data from the production website. Running these commands for the second time is recommended only if data import was not complete or got corrupted. Partial imports can be done by running individual commands where all previous node IDs will be updated (assigned new).
 
+```
 ./vendor/bin/drush migrate:import --group=legacy_taxonomies --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_media --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_paragraphs --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_nodes --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_documents --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_basic_page --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_page_news --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_user_role --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_menu continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_files --continue-on-failure
+```
 
+The script `migrate_initial.sh` does the above.
 
 ### Reset migration in case of failure
 
 Migrations can fail to complete due to multiple reasons and when it happens, it display the name of the table for which migration stopped working.  Rerunning (resume) the migration is only possible after resetting the migration using a command like below where “yukon_migrate_landing_page” is the name of the failed table. 
 
-./vendor/bin/drush migrate:reset-status yukon_migrate_landing_page
+    ./vendor/bin/drush migrate:reset-status yukon_migrate_landing_page
 
 
 ### Update - 2nd Round to update relationships
 
+```
 ./vendor/bin/drush migrate:import --group=legacy_taxonomies --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_media --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_paragraphs --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_nodes --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_documents --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_basic_page --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_page_news --update --continue-on-failure
-
 ./vendor/bin/drush migrate:import --group=legacy_user_role --update --continue-on-failure
-
-./vendor/bin/drush migrate:import --group=legacy_menu --update continue-on-failure
-
+./vendor/bin/drush migrate:import --group=legacy_menu --update --continue-on-failure
 ./vendor/bin/drush migrate:import --group=legacy_files --update --continue-on-failure
+```
+
+The script `migrate_update.sh` does the above.
 
 Running the above commands more than once is recommended.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The script `migrate_update.sh` does the above.
 
 Running the above commands more than once is recommended.
 
+### Post-import cleanup
+
+The `custom_migrate` module does some post-migration clean up work. Visit `[root-URL]/custom_migrate` to execute that code.
+
 ## Run the following commands after migrating the data:
 
 After completing the data migration and its update, the following commands may be run to setup the theme files.

--- a/migrate_initial.sh
+++ b/migrate_initial.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# From https://github.com/ralish/bash-script-template
+#
+# A best practices Bash script template with many useful functions. This file
+# sources in the bulk of the functions from the source.sh file which it expects
+# to be in the same directory. Only those functions which are likely to need
+# modification are present in this file. This is a great combination if you're
+# writing several scripts! By pulling in the common functions you'll minimise
+# code duplication, as well as ease any potential updates to shared functions.
+
+# Enable xtrace if the DEBUG environment variable is set
+if [[ ${DEBUG-} =~ ^1|yes|true$ ]]; then
+    set -o xtrace       # Trace the execution of the script (debug)
+fi
+
+# Only enable these shell behaviours if we're not being sourced
+# Approach via: https://stackoverflow.com/a/28776166/8787985
+if ! (return 0 2> /dev/null); then
+    # A better class of script...
+    set -o errexit      # Exit on most errors (see the manual)
+    set -o nounset      # Disallow expansion of unset variables
+    set -o pipefail     # Use last non-zero exit code in a pipeline
+fi
+
+# Enable errtrace or the error trap handler will not work as expected
+set -o errtrace         # Ensure the error trap handler is inherited
+
+date
+
+time drush migrate:import --group=legacy_taxonomies --continue-on-failure
+time drush migrate:import --group=legacy_media --continue-on-failure
+time drush migrate:import --group=legacy_paragraphs --continue-on-failure
+time drush migrate:import --group=legacy_nodes --continue-on-failure
+time drush migrate:import --group=legacy_documents --continue-on-failure
+time drush migrate:import --group=legacy_basic_page --continue-on-failure
+time drush migrate:import --group=legacy_page_news --continue-on-failure
+time drush migrate:import --group=legacy_user_role --continue-on-failure
+time drush migrate:import --group=legacy_menu --continue-on-failure
+time drush migrate:import --group=legacy_files --continue-on-failure
+
+date

--- a/migrate_update.sh
+++ b/migrate_update.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# From https://github.com/ralish/bash-script-template
+#
+# A best practices Bash script template with many useful functions. This file
+# sources in the bulk of the functions from the source.sh file which it expects
+# to be in the same directory. Only those functions which are likely to need
+# modification are present in this file. This is a great combination if you're
+# writing several scripts! By pulling in the common functions you'll minimise
+# code duplication, as well as ease any potential updates to shared functions.
+
+# Enable xtrace if the DEBUG environment variable is set
+if [[ ${DEBUG-} =~ ^1|yes|true$ ]]; then
+    set -o xtrace       # Trace the execution of the script (debug)
+fi
+
+# Only enable these shell behaviours if we're not being sourced
+# Approach via: https://stackoverflow.com/a/28776166/8787985
+if ! (return 0 2> /dev/null); then
+    # A better class of script...
+    set -o errexit      # Exit on most errors (see the manual)
+    set -o nounset      # Disallow expansion of unset variables
+    set -o pipefail     # Use last non-zero exit code in a pipeline
+fi
+
+# Enable errtrace or the error trap handler will not work as expected
+set -o errtrace         # Ensure the error trap handler is inherited
+
+date
+
+time drush migrate:import --group=legacy_taxonomies  --update --continue-on-failure
+time drush migrate:import --group=legacy_media       --update --continue-on-failure
+time drush migrate:import --group=legacy_paragraphs  --update --continue-on-failure
+time drush migrate:import --group=legacy_nodes       --update --continue-on-failure
+time drush migrate:import --group=legacy_documents   --update --continue-on-failure
+time drush migrate:import --group=legacy_basic_page  --update --continue-on-failure
+time drush migrate:import --group=legacy_page_news   --update --continue-on-failure
+time drush migrate:import --group=legacy_user_role   --update --continue-on-failure
+time drush migrate:import --group=legacy_menu        --update --continue-on-failure
+time drush migrate:import --group=legacy_files       --update --continue-on-failure
+
+date


### PR DESCRIPTION
Adding two scripts, `migrate_initial.sh` and `migrate_update.sh` to normalize the data migration process.

This should close #484.