### PR TITLE
Mutlidev corrections: Task #64790: WYSIWYG Settings

### DIFF
--- a/config/default/editor.editor.basic_html.yml
+++ b/config/default/editor.editor.basic_html.yml
@@ -1,6 +1,6 @@
 uuid: 7ab578b6-36fb-4975-b377-e9f660591053
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - filter.format.basic_html

--- a/config/default/editor.editor.full_html.yml
+++ b/config/default/editor.editor.full_html.yml
@@ -62,4 +62,6 @@ settings:
     linkit_extension:
       linkit_enabled: true
       linkit_profile: ckeditor
+    media_media:
+      allow_view_mode_override: false
 image_upload: {  }

--- a/config/default/editor.editor.full_html.yml
+++ b/config/default/editor.editor.full_html.yml
@@ -17,22 +17,20 @@ settings:
       - subscript
       - superscript
       - alignment
-      - fontSize
       - bulletedList
       - numberedList
       - indent
       - outdent
       - blockQuote
       - link
-      - DivManager
       - undo
       - redo
-      - findAndReplace
+      - insertTable
       - removeFormat
       - anchor
       - horizontalLine
-      - insertTable
       - ShowBlocks
+      - findAndReplace
       - selectAll
       - sourceEditing
       - fullScreen
@@ -53,8 +51,6 @@ settings:
     ckeditor5_list:
       reversed: true
       startIndex: true
-    ckeditor5_plugin_pack_font__font_size:
-      options: ''
     ckeditor5_show_block_show_block:
       enable_show_block_default: 0
     ckeditor5_sourceEditing:

--- a/config/default/editor.editor.full_html.yml
+++ b/config/default/editor.editor.full_html.yml
@@ -14,13 +14,35 @@ settings:
       - heading
       - bold
       - italic
+      - subscript
+      - superscript
+      - alignment
+      - fontSize
       - bulletedList
       - numberedList
+      - indent
+      - outdent
+      - blockQuote
       - link
-      - underline
-      - sourceEditing
+      - DivManager
+      - undo
+      - redo
+      - findAndReplace
       - removeFormat
+      - anchor
+      - horizontalLine
+      - insertTable
+      - ShowBlocks
+      - selectAll
+      - sourceEditing
+      - fullScreen
   plugins:
+    ckeditor5_alignment:
+      enabled_alignments:
+        - center
+        - justify
+        - left
+        - right
     ckeditor5_heading:
       enabled_headings:
         - heading2
@@ -31,6 +53,10 @@ settings:
     ckeditor5_list:
       reversed: true
       startIndex: true
+    ckeditor5_plugin_pack_font__font_size:
+      options: ''
+    ckeditor5_show_block_show_block:
+      enable_show_block_default: 0
     ckeditor5_sourceEditing:
       allowed_tags: {  }
     linkit_extension:

--- a/config/default/editor.editor.wysiwyg_ckeditor.yml
+++ b/config/default/editor.editor.wysiwyg_ckeditor.yml
@@ -1,6 +1,6 @@
 uuid: 74861d14-0377-44fb-add4-ec40458c77e2
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - filter.format.wysiwyg_ckeditor

--- a/config/default/filter.format.basic_html.yml
+++ b/config/default/filter.format.basic_html.yml
@@ -9,7 +9,7 @@ _core:
   default_config_hash: P8ddpAIKtawJDi5SzOwCzVnnNYqONewSTJ6Xn0dW_aQ
 name: 'Basic HTML'
 format: basic_html
-weight: -7
+weight: -10
 filters:
   filter_html:
     id: filter_html

--- a/config/default/filter.format.basic_html.yml
+++ b/config/default/filter.format.basic_html.yml
@@ -1,6 +1,6 @@
 uuid: 179bfef0-3544-49f0-bf8b-a1b6cbb66740
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - editor
@@ -9,7 +9,7 @@ _core:
   default_config_hash: P8ddpAIKtawJDi5SzOwCzVnnNYqONewSTJ6Xn0dW_aQ
 name: 'Basic HTML'
 format: basic_html
-weight: -10
+weight: -9
 filters:
   filter_html:
     id: filter_html

--- a/config/default/filter.format.full_html.yml
+++ b/config/default/filter.format.full_html.yml
@@ -11,7 +11,7 @@ _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
 name: 'Full HTML'
 format: full_html
-weight: -9
+weight: -10
 filters:
   filter_align:
     id: filter_align

--- a/config/default/filter.format.full_html.yml
+++ b/config/default/filter.format.full_html.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - editor
     - linkit
+    - media
     - pathologic
 _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
@@ -76,3 +77,14 @@ filters:
     status: true
     weight: 0
     settings: {  }
+  media_embed:
+    id: media_embed
+    provider: media
+    status: true
+    weight: 100
+    settings:
+      default_view_mode: default
+      allowed_view_modes:
+        default: default
+      allowed_media_types:
+        image: image

--- a/config/default/filter.format.full_html.yml
+++ b/config/default/filter.format.full_html.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   module:
     - editor
+    - linkit
     - pathologic
 _core:
   default_config_hash: hewPmBgni9jlDK_IjLxUx1HsTbinK-hdl0lOwjbteIY
@@ -14,13 +15,13 @@ filters:
   filter_align:
     id: filter_align
     provider: filter
-    status: true
+    status: false
     weight: 8
     settings: {  }
   filter_caption:
     id: filter_caption
     provider: filter
-    status: true
+    status: false
     weight: 9
     settings: {  }
   filter_htmlcorrector:
@@ -38,10 +39,10 @@ filters:
   filter_html:
     id: filter_html
     provider: filter
-    status: true
+    status: false
     weight: -10
     settings:
-      allowed_html: '<br> <p> <h2> <h3> <h4> <h5> <h6> <strong> <em> <u> <a href data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol reversed start> <li>'
+      allowed_html: ''
       filter_html_help: false
       filter_html_nofollow: false
   filter_url:
@@ -54,11 +55,24 @@ filters:
   filter_pathologic:
     id: filter_pathologic
     provider: pathologic
-    status: false
+    status: true
     weight: 50
     settings:
-      settings_source: global
+      settings_source: local
       local_settings:
         protocol_style: full
-        local_paths: ''
+        local_paths: "/en/\r\n/fr/\r\nhttps://yukon.ca/en/\r\nhttps://yukon.ca/fr/"
         keep_language_prefix: true
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: 0
+    settings:
+      title: true
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }

--- a/config/default/filter.format.wysiwyg_ckeditor.yml
+++ b/config/default/filter.format.wysiwyg_ckeditor.yml
@@ -1,6 +1,6 @@
 uuid: f719703d-1070-4053-8b3e-d34f03baa903
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - linkit

--- a/config/default/language/fr/views.view.news_listing.yml
+++ b/config/default/language/fr/views.view.news_listing.yml
@@ -19,9 +19,6 @@ display:
         field_news_type_target_id:
           expose:
             label: "Type d'actualité"
-        field_featured_content_value:
-          expose:
-            description: ''
   block_news_listing:
     display_options:
       filters:

--- a/config/default/pathologic.settings.yml
+++ b/config/default/pathologic.settings.yml
@@ -1,9 +1,9 @@
 _core:
   default_config_hash: EKYCulG-Y3pcObfUpVbl-D9T5DDX6d4hpQ-BVlSBAmw
+protocol_style: full
+local_paths: ''
 scheme_whitelist:
   - http
   - https
   - files
   - internal
-protocol_style: full
-local_paths: ''

--- a/config/default/user.role.author_in_page_alerts.yml
+++ b/config/default/user.role.author_in_page_alerts.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -37,7 +36,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view any unpublished content'
   - 'view the administration theme'

--- a/config/default/user.role.author_in_page_alerts.yml
+++ b/config/default/user.role.author_in_page_alerts.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -34,7 +33,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view any unpublished content'

--- a/config/default/user.role.blog_author.yml
+++ b/config/default/user.role.blog_author.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -43,7 +42,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/user.role.blog_author.yml
+++ b/config/default/user.role.blog_author.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -40,7 +39,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -42,7 +41,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -45,7 +44,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -47,7 +46,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -44,7 +43,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.site_administrator.yml
+++ b/config/default/user.role.site_administrator.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -108,7 +107,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.site_administrator.yml
+++ b/config/default/user.role.site_administrator.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - block
@@ -111,7 +110,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/user.role.team_administrator.yml
+++ b/config/default/user.role.team_administrator.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
   module:
     - contextual
@@ -31,7 +30,6 @@ permissions:
   - 'administer workbench access'
   - 'assign workbench access'
   - 'batch update workbench access'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view own unpublished content'

--- a/config/default/user.role.team_administrator.yml
+++ b/config/default/user.role.team_administrator.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
   module:
     - contextual
     - filter
@@ -34,7 +33,6 @@ permissions:
   - 'batch update workbench access'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view own unpublished content'
   - 'view the administration theme'

--- a/config/default/user.role.translator.yml
+++ b/config/default/user.role.translator.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -57,7 +56,6 @@ permissions:
   - 'use content transition publish'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.translator.yml
+++ b/config/default/user.role.translator.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -60,7 +59,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/user.role.writer.yml
+++ b/config/default/user.role.writer.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.basic_html
     - filter.format.full_html
     - workflows.workflow.content
   module:
@@ -38,7 +37,6 @@ permissions:
   - 'use content transition create_new_draft'
   - 'use content transition create_new_draft'
   - 'use content transition submit_for_review'
-  - 'use text format basic_html'
   - 'use text format full_html'
   - 'use workbench access'
   - 'view all revisions'

--- a/config/default/user.role.writer.yml
+++ b/config/default/user.role.writer.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
-    - filter.format.wysiwyg_ckeditor
     - workflows.workflow.content
   module:
     - content_moderation
@@ -41,7 +40,6 @@ permissions:
   - 'use content transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format full_html'
-  - 'use text format wysiwyg_ckeditor'
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'

--- a/config/default/views.view.blog_listing.yml
+++ b/config/default/views.view.blog_listing.yml
@@ -376,7 +376,7 @@ display:
           empty: true
           content:
             value: 'No blog posts found. Try removing or changing a filter.'
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         created:

--- a/config/default/views.view.engagements.yml
+++ b/config/default/views.view.engagements.yml
@@ -128,7 +128,7 @@ display:
           empty: true
           content:
             value: 'No open engagements found'
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         created:

--- a/config/default/views.view.event_listing.yml
+++ b/config/default/views.view.event_listing.yml
@@ -579,7 +579,7 @@ display:
           empty: true
           content:
             value: 'No events found. Try removing or changing a filter.'
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         field_event_start_time_value:
@@ -885,7 +885,7 @@ display:
           empty: false
           content:
             value: '<h2>Featured events</h2>'
-            format: basic_html
+            format: full_html
           tokenize: false
       footer: {  }
       display_extenders: {  }

--- a/config/default/views.view.news_listing.yml
+++ b/config/default/views.view.news_listing.yml
@@ -510,7 +510,7 @@ display:
           empty: true
           content:
             value: 'No news items found. Try removing or changing a filter.'
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         created:
@@ -3253,7 +3253,7 @@ display:
             empty: true
             content:
               value: 'No news items found. Try removing or changing a filter.'
-              format: basic_html
+              format: plain_text
             tokenize: false
         sorts:
           created:

--- a/config/default/views.view.workbench_current_user.yml
+++ b/config/default/views.view.workbench_current_user.yml
@@ -424,7 +424,7 @@ display:
           empty: false
           content:
             value: "<h3>{{ name }}'s profile</h3>"
-            format: basic_html
+            format: full_html
           tokenize: true
       footer: {  }
       display_extenders: {  }

--- a/config/default/views.view.workbench_edited.yml
+++ b/config/default/views.view.workbench_edited.yml
@@ -533,7 +533,7 @@ display:
           empty: true
           content:
             value: "You haven't created or edited any content."
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         changed:
@@ -971,7 +971,7 @@ display:
           empty: false
           content:
             value: '<h3>Your most recent edits</h3>'
-            format: basic_html
+            format: full_html
           tokenize: false
       footer: {  }
       display_extenders: {  }

--- a/config/default/views.view.workbench_recent_content.yml
+++ b/config/default/views.view.workbench_recent_content.yml
@@ -451,7 +451,7 @@ display:
           empty: true
           content:
             value: 'There is no content available for you to edit.'
-            format: basic_html
+            format: plain_text
           tokenize: false
       sorts:
         changed:
@@ -1157,7 +1157,7 @@ display:
           empty: false
           content:
             value: '<h3>Recent content</h3>'
-            format: basic_html
+            format: full_html
           tokenize: false
       display_extenders: {  }
     cache_metadata:

--- a/config/default/webform.webform.contact.yml
+++ b/config/default/webform.webform.contact.yml
@@ -16,7 +16,7 @@ archive: false
 id: contact
 title: Contact
 description: 'Basic email contact webform.'
-category: ''
+categories: {  }
 elements: |
   name:
     '#title': 'Your Name'

--- a/config/default/webform.webform.page_feedback.yml
+++ b/config/default/webform.webform.page_feedback.yml
@@ -11,7 +11,7 @@ archive: false
 id: page_feedback
 title: 'Page feedback'
 description: ''
-category: ''
+categories: {  }
 elements: |-
   page_title:
     '#type': value


### PR DESCRIPTION
Changes:

- Copy confirugation from 'WYSIWYG CKEDITOR' text-format into 'Full HTML' text-format
- Enable media support for 'Full HTML' text-editor
- disable 'WYSIWYG CKEDITOR' text-format
- Reorder CKEditor buttons for 'Full HTML' text-editor
- enable correct Linkit profile for 'Full HTML' text-editor
- disable 'Basic HTML' text-editor
- update affected views to stop using 'Basic HTML' text-editor