### PR TITLE
refs #64790: Re-order buttons in CKEditor for 'Full HTML' text-editor…

### DIFF
--- a/config/default/editor.editor.full_html.yml
+++ b/config/default/editor.editor.full_html.yml
@@ -14,22 +14,22 @@ settings:
       - heading
       - bold
       - italic
-      - subscript
-      - superscript
       - alignment
       - bulletedList
       - numberedList
+      - drupalMedia
       - indent
       - outdent
       - blockQuote
       - link
       - undo
       - redo
-      - drupalMedia
       - insertTable
       - removeFormat
       - anchor
       - horizontalLine
+      - superscript
+      - subscript
       - ShowBlocks
       - findAndReplace
       - selectAll


### PR DESCRIPTION
… to keep 'image-media embed' button be shown in toolbar.