### PR TITLE
Task #64789: Preview missing

### DIFF
--- a/config/default/node.type.basic_page.yml
+++ b/config/default/node.type.basic_page.yml
@@ -28,5 +28,5 @@ type: basic_page
 description: ''
 help: ''
 new_revision: true
-preview_mode: 0
+preview_mode: 1
 display_submitted: false

--- a/config/default/node.type.in_page_alert.yml
+++ b/config/default/node.type.in_page_alert.yml
@@ -27,5 +27,5 @@ type: in_page_alert
 description: 'Create an alert to share urgent information with users. These can be displayed on a specific page.'
 help: ''
 new_revision: true
-preview_mode: 0
+preview_mode: 1
 display_submitted: false

--- a/config/default/node.type.site_wide_alert.yml
+++ b/config/default/node.type.site_wide_alert.yml
@@ -27,5 +27,5 @@ type: site_wide_alert
 description: 'This alert is displayed at the top of all pages, to share urgent announcements with users. Images should not be used.'
 help: ''
 new_revision: true
-preview_mode: 0
+preview_mode: 1
 display_submitted: false

--- a/config/default/node.type.topics_page.yml
+++ b/config/default/node.type.topics_page.yml
@@ -28,5 +28,5 @@ type: topics_page
 description: 'Use for a collection of related links.'
 help: ''
 new_revision: true
-preview_mode: 0
+preview_mode: 1
 display_submitted: false


### PR DESCRIPTION
Enable 'preview' ability for content types
- Basic page
- In-Page Alert
- Site-Wide Alert
- Topics Page

In result - all content types have 'preview' ability.