### PR TITLE
Migrate the correct "Site description" Campground field

### DIFF
--- a/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_campground_directory_record.yml
+++ b/docroot/modules/custom/yukon_migrate/migrations/nodes/yukon_migrate_campground_directory_record.yml
@@ -136,7 +136,7 @@ process:
   field_site_description/0/value:
     plugin: yukon_migrate_uri_transform
     method: transformUri
-    source: field_site_description_app_/0/value
+    source: field_campground_description/0/value
   field_site_description/format: constants/default_text_format
 
   field_site_description_app/value: field_site_description_app_/0/value


### PR DESCRIPTION
Fixes #544

Note: This doesn't result in the site description field looking right. It's output as plain text (so you can see the HTML tags). That's a different issue.

This change migrates the correct data into the "Site description" field.