### PR TITLE
eServices - Add and setup matomo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "drupal/linkchecker": "^2.0@alpha",
         "drupal/linkit": "^6.1",
         "drupal/mail_safety": "^2.0",
+        "drupal/matomo": "^1.23",
         "drupal/maxlength": "^2.1",
         "drupal/media_directories": "2.1.x-dev@dev",
         "drupal/media_library_edit": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64233534979b841763a3a24e6c355c76",
+    "content-hash": "fa5b290b72128361016f35deeadd00a7",
     "packages": [
         {
             "name": "acquia/blt",
@@ -6267,6 +6267,70 @@
             "homepage": "https://www.drupal.org/project/mail_safety",
             "support": {
                 "source": "https://git.drupalcode.org/project/mail_safety"
+            }
+        },
+        {
+            "name": "drupal/matomo",
+            "version": "1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/matomo.git",
+                "reference": "8.x-1.23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/matomo-8.x-1.23.zip",
+                "reference": "8.x-1.23",
+                "shasum": "c2dbf12878388c5859e64f1e74a9ca5110d1623f"
+            },
+            "require": {
+                "drupal/core": "^9.0 || ^10"
+            },
+            "conflict": {
+                "drupal/csp": "<1.12"
+            },
+            "require-dev": {
+                "drupal/csp": "~1.12",
+                "drupal/php": "~1.1",
+                "drupal/token": "~1.9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.23",
+                    "datestamp": "1700936102",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "C-Logemann",
+                    "homepage": "https://www.drupal.org/user/218368"
+                },
+                {
+                    "name": "Grimreaper",
+                    "homepage": "https://www.drupal.org/user/2388214"
+                },
+                {
+                    "name": "hass",
+                    "homepage": "https://www.drupal.org/user/85918"
+                },
+                {
+                    "name": "shelane",
+                    "homepage": "https://www.drupal.org/user/2674989"
+                }
+            ],
+            "description": "Adds Matomo javascript tracking code to all your site's pages.",
+            "homepage": "https://www.drupal.org/project/matomo",
+            "support": {
+                "source": "https://git.drupalcode.org/project/matomo"
             }
         },
         {

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -79,6 +79,7 @@ module:
   linkit: 0
   locale: 0
   mail_safety: 0
+  matomo: 0
   maxlength: 0
   media: 0
   media_directories: 0

--- a/config/default/matomo.settings.yml
+++ b/config/default/matomo.settings.yml
@@ -1,0 +1,61 @@
+_core:
+  default_config_hash: mKwnhF-0ryfftZZP6jyqW8q9MEo9glyRkvRzSddrc0k
+site_id: '4'
+url_http: 'http://analytics.gov.yk.ca/'
+url_https: 'https://analytics.gov.yk.ca/'
+domain_mode: 0
+visibility:
+  request_path_mode: 0
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
+  user_role_mode: 0
+  user_role_roles:
+    anonymous: anonymous
+  user_account_mode: 0
+track:
+  mailto: true
+  files: true
+  files_extensions: '7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip'
+  colorbox: true
+  userid: false
+  messages:
+    error: error
+  site_search: false
+privacy:
+  donottrack: true
+  disablecookies: false
+custom:
+  variable:
+    1:
+      slot: 1
+      name: ''
+      value: ''
+      scope: visit
+    2:
+      slot: 2
+      name: ''
+      value: ''
+      scope: visit
+    3:
+      slot: 3
+      name: ''
+      value: ''
+      scope: visit
+    4:
+      slot: 4
+      name: ''
+      value: ''
+      scope: visit
+    5:
+      slot: 5
+      name: ''
+      value: ''
+      scope: visit
+codesnippet:
+  before: ''
+  after: ''
+translation_set: false
+disable_tracking: false
+cache: false
+page_title_hierarchy: false
+page_title_hierarchy_exclude_home: true
+status_codes_disabled: {  }

--- a/config/default/user.role.authenticated.yml
+++ b/config/default/user.role.authenticated.yml
@@ -5,6 +5,7 @@ dependencies:
   module:
     - block
     - comment
+    - matomo
     - media
     - system
 _core:
@@ -18,6 +19,7 @@ permissions:
   - 'access content'
   - 'administer blocks'
   - 'administer blocks'
+  - 'opt-in or out of matomo tracking'
   - 'post comments'
   - 'view media'
   - 'view media'

--- a/config/default/views.settings.yml
+++ b/config/default/views.settings.yml
@@ -2,6 +2,7 @@ _core:
   default_config_hash: uZHsLrDp1ThO0RvupHKcPzLOyVvWexm58JTTHNDo7yc
 display_extenders:
   - ajax_history
+  - matomo
 sql_signature: false
 ui:
   show:


### PR DESCRIPTION
# What's included

Matomo web analytics. Closes #661.

# Notes

The configuration captured is for the test site, `4`. This is appropriate for testing, but should be changed for production.

# Deployment instructions

1. Roll out code. 
2. Composer install
3. Import config. `drush config:import`

To customize settings (e.g. change site ID), visit `en/admin/config/system/matomo`