### PR TITLE
eServices - Workflow tweak to allow direct publication

### DIFF
--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -123,6 +123,7 @@ permissions:
   - 'use content transition publish'
   - 'use content transition publish'
   - 'use content transition publish'
+  - 'use content transition publish_directly'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use workbench access'

--- a/config/default/user.role.site_administrator.yml
+++ b/config/default/user.role.site_administrator.yml
@@ -200,6 +200,7 @@ permissions:
   - 'use content transition publish'
   - 'use content transition publish'
   - 'use content transition publish'
+  - 'use content transition publish_directly'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use workbench access'

--- a/config/default/workflows.workflow.content.yml
+++ b/config/default/workflows.workflow.content.yml
@@ -79,6 +79,13 @@ type_settings:
         - ready_to_publish
       to: published
       weight: 1
+    publish_directly:
+      label: 'Publish directly'
+      from:
+        - draft
+        - published
+      to: published
+      weight: 7
     reject:
       label: Reject
       from:


### PR DESCRIPTION
# What's included

Allow certain users to publish directly, skipping the interim workflow steps. This helps with #508.

A new workflow transition "Publish directly", move content from Draft, Published, Archived states to Published state.

This transition is available to users with the Publisher or Site Administrator role.

# Deployment steps

1. Roll out the code
2. Config import

