### PR TITLE
eServices - Fixup for #664

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -103,7 +103,6 @@ module:
   options: 0
   page_cache: 0
   page_manager: 0
-  pantheon_advanced_page_cache: 0
   path: 0
   path_alias: 0
   pathologic: 0

--- a/config/default/low_seetings.settings.yml
+++ b/config/default/low_seetings.settings.yml
@@ -1,5 +1,0 @@
-goy_wildfire_low_bandwidth_districts_url: 'https://services.arcgis.com/bwohQix8s7zRvYC9/ArcGIS/rest/services/FireDistrictsForAGOL/FeatureServer/1/'
-goy_wildfire_low_bandwidth_wildfire_status_url: 'https://services.arcgis.com/bwohQix8s7zRvYC9/ArcGIS/rest/services/WildfireStatus_2024_view/FeatureServer/0/'
-goy_wildfire_low_bandwidth_where_clause: 'query?where=initial_report_date%3E%3D%272024-04-01%27%20and%20fire_district_name'
-goy_wildfire_low_bandwidth_suffix: '&f=pjson&returnGeometry=false&outFields=*'
-goy_wildfire_low_bandwidth_cache_lifetime_seconds: '300'

--- a/config/default/pantheon_advanced_page_cache.settings.yml
+++ b/config/default/pantheon_advanced_page_cache.settings.yml
@@ -1,3 +1,0 @@
-_core:
-  default_config_hash: nYV-pR4XH4jgCkcYZZePzg9RYTFXR5YNw-F1iaP6qio
-override_list_tags: false


### PR DESCRIPTION
# What's included

This change fixes two problems with the exported site configuration that landed as part of #664.

- Remove Pantheon Advanced Page Cache (for #512)
- Remove Low-Bandwidth config (probably part of #638)

These changes fix a problem with `drush config:import`, as reported in this comment: https://github.com/ytgov/yukon-ca/pull/664#issuecomment-2452728119

# Deployment instructions

Just the regular.