### PR TITLE
eServices - bring SSO to w3_staging_yukon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,8 @@
         "drupal/migrate_scanner": "^1.0",
         "drupal/migrate_tools": "^6.0",
         "drupal/moderation_scheduler": "^9.1",
+        "drupal/noreqnewpass": "^1.4",
+        "drupal/openid_connect": "^1.4",
         "drupal/page_manager": "^4.0@RC",
         "drupal/paragraphs": "^1.12",
         "drupal/password_policy": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97203658c2e8a7569d233e2834103d62",
+    "content-hash": "e66a9d4bcb6c3db7e58f08bbf076e0f4",
     "packages": [
         {
             "name": "acquia/blt",
@@ -7138,6 +7138,129 @@
             "homepage": "https://www.drupal.org/project/moderation_scheduler",
             "support": {
                 "source": "https://git.drupalcode.org/project/moderation_scheduler"
+            }
+        },
+        {
+            "name": "drupal/noreqnewpass",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/noreqnewpass.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/noreqnewpass-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "b3fd5499d8a371ff1c259e371284c48602b9dbc3"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10 || ^11"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1727698112",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/u/neslee-canil-pinto",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "neslee canil pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
+                },
+                {
+                    "name": "pedrofaria",
+                    "homepage": "https://www.drupal.org/user/27805"
+                },
+                {
+                    "name": "University of Colorado Boulder",
+                    "homepage": "https://www.drupal.org/user/3299791"
+                }
+            ],
+            "description": "Disable link to request a new password.",
+            "homepage": "https://www.drupal.org/project/noreqnewpass",
+            "support": {
+                "source": "https://git.drupalcode.org/project/noreqnewpass",
+                "issues": "https://www.drupal.org/project/issues/noreqnewpass"
+            }
+        },
+        {
+            "name": "drupal/openid_connect",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/openid_connect.git",
+                "reference": "8.x-1.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/openid_connect-8.x-1.4.zip",
+                "reference": "8.x-1.4",
+                "shasum": "9bdbfa6365d10b2029bdaee9fbd82265aa6d4fa4"
+            },
+            "require": {
+                "drupal/core": "^9.5 || ^10",
+                "ext-json": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.4",
+                    "datestamp": "1698170385",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bojanz",
+                    "homepage": "https://www.drupal.org/user/86106"
+                },
+                {
+                    "name": "jcnventura",
+                    "homepage": "https://www.drupal.org/user/122464"
+                },
+                {
+                    "name": "pfrilling",
+                    "homepage": "https://www.drupal.org/user/169695"
+                },
+                {
+                    "name": "pjcdawkins",
+                    "homepage": "https://www.drupal.org/user/1025236"
+                },
+                {
+                    "name": "sanduhrs",
+                    "homepage": "https://www.drupal.org/user/28074"
+                }
+            ],
+            "description": "A pluggable client implementation for the OpenID Connect protocol.",
+            "homepage": "https://www.drupal.org/project/openid_connect",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "source": "https://git.drupalcode.org/project/openid_connect",
+                "issues": "https://www.drupal.org/project/issues/openid_connect"
             }
         },
         {
@@ -17931,6 +18054,6 @@
     "platform": {
         "php": ">=8.1"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -105,6 +105,8 @@ module:
   module_missing_message_fixer: 0
   mysql: 0
   node: 0
+  noreqnewpass: 0
+  openid_connect: 0
   options: 0
   page_cache: 0
   page_manager: 0
@@ -168,6 +170,7 @@ module:
   yukon_department: 0
   yukon_migrate: 0
   yukon_moderation: 0
+  yukon_sso: 0
   yukon_taxonomy: 0
   yukon_w3_custom: 0
   yukon_w3_migrate: 0

--- a/config/default/noreqnewpass.settings_form.yml
+++ b/config/default/noreqnewpass.settings_form.yml
@@ -1,0 +1,1 @@
+noreqnewpass_disable: 1

--- a/config/default/openid_connect.settings.facebook.yml
+++ b/config/default/openid_connect.settings.facebook.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: XE2MqevnEK7g2Hi3bBsxJUUcbYQBm9AjQR6foDyycRY
+enabled: false
+settings:
+  client_id: null
+  client_secret: null
+  api_version: null

--- a/config/default/openid_connect.settings.generic.yml
+++ b/config/default/openid_connect.settings.generic.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: FJ7FfwlYzcbFfG0AqVPlqsLJIRhkzS1Rv6eO1vssSkM
+enabled: true
+settings:
+  client_id: syKVrWIsOxdSPwP9FcnluLQtORRGLKHm
+  client_secret: oexQNebea8Y4F_ZYzx5NB52y02zNiYTbgMky5UWJajisN-5qMpA1HC2V9uWYUrxG
+  authorization_endpoint: 'https://dev-0tc6bn14.eu.auth0.com/authorize'
+  token_endpoint: 'https://dev-0tc6bn14.eu.auth0.com/oauth/token'
+  userinfo_endpoint: 'https://dev-0tc6bn14.eu.auth0.com/userinfo'
+  redirect_url: ''

--- a/config/default/openid_connect.settings.github.yml
+++ b/config/default/openid_connect.settings.github.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/default/openid_connect.settings.google.yml
+++ b/config/default/openid_connect.settings.google.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/default/openid_connect.settings.linkedin.yml
+++ b/config/default/openid_connect.settings.linkedin.yml
@@ -1,0 +1,6 @@
+_core:
+  default_config_hash: h0ctmI-lSknN6e9qvO8PKjAPEeopeDR4FnxTYhGcD1k
+enabled: false
+settings:
+  client_id: null
+  client_secret: null

--- a/config/default/openid_connect.settings.okta.yml
+++ b/config/default/openid_connect.settings.okta.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 7F1ngE9fiONEo0Nk1cfez_GTGzhHBLuPaHlrDqYI_hg
+enabled: false
+settings:
+  client_id: null
+  client_secret: null
+  okta_domain: null

--- a/config/default/openid_connect.settings.yml
+++ b/config/default/openid_connect.settings.yml
@@ -1,0 +1,8 @@
+_core:
+  default_config_hash: YpBA3MmDuJpZ9SM3DE4kR0lTY89bf2y3g0sS7s3TQ4k
+always_save_userinfo: true
+connect_existing_users: true
+override_registration_settings: true
+user_login_display: replace
+userinfo_mappings:
+  timezone: zoneinfo

--- a/docroot/modules/custom/yukon_sso/yukon_sso.info.yml
+++ b/docroot/modules/custom/yukon_sso/yukon_sso.info.yml
@@ -1,0 +1,7 @@
+name: Yukon SOO
+type: module
+description: Supporting module for SSO to provide supporting role assignment.
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - openid_connect:openid_connect

--- a/docroot/modules/custom/yukon_sso/yukon_sso.module
+++ b/docroot/modules/custom/yukon_sso/yukon_sso.module
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @file
+ * Main module file.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_openid_connect_userinfo_save().
+ */
+function yukon_sso_openid_connect_userinfo_save($account, $context) {
+  // All roles should be updated on each authorization.
+  // Delete all user roles.
+  foreach ($account->getRoles() as $role) {
+    $account->removeRole($role);
+  }
+
+  // Assign roles according to SSO response.
+  if (!empty($context['user_data']['urn:myyukon.ca/groups'])) {
+    $roles_mapping = yukon_sso_get_roles_mapping();
+    foreach ($context['user_data']['urn:myyukon.ca/groups'] as $auth0_role) {
+      if (isset($roles_mapping[$auth0_role])) {
+        $account->addRole($roles_mapping[$auth0_role]);
+      }
+      else {
+        \Drupal::logger('yukon_sso')->alert("Mapping error for SSO role: '{$auth0_role}'. There is no mapping for this role. Account: {$account->getAccountName()}");
+      }
+    }
+  }
+}
+
+/**
+ * SSO and Drupal roles mapping.
+ *
+ * @return array
+ *   Roles mapping list.
+ */
+function yukon_sso_get_roles_mapping(): array {
+  return [
+    'web-admin' => 'site_administrator',
+    'web-trans' => 'translator',
+    'web-team' => 'team_administrator',
+    'web-alerts' => 'author_in_page_alerts',
+    'web-pub' => 'publisher',
+    'web-editor' => 'editor',
+    'web-writer' => 'writer',
+  ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function yukon_sso_form_openid_connect_login_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  $form['openid_connect_client_generic_login']['#value'] = t('Log in with MyYukon');
+}

--- a/docroot/modules/custom/yukon_sso/yukon_sso.module
+++ b/docroot/modules/custom/yukon_sso/yukon_sso.module
@@ -11,21 +11,21 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_openid_connect_userinfo_save().
  */
 function yukon_sso_openid_connect_userinfo_save($account, $context) {
-  // All roles should be updated on each authorization.
-  // Delete all user roles.
+  $roles_mapping = yukon_sso_get_roles_mapping();
+
+  // SSO roles should be updated on each authorization.
+  // Delete all SSO user roles.
   foreach ($account->getRoles() as $role) {
-    $account->removeRole($role);
+    if (in_array($role, $roles_mapping)) {
+      $account->removeRole($role);
+    }
   }
 
   // Assign roles according to SSO response.
   if (!empty($context['user_data']['urn:myyukon.ca/groups'])) {
-    $roles_mapping = yukon_sso_get_roles_mapping();
     foreach ($context['user_data']['urn:myyukon.ca/groups'] as $auth0_role) {
       if (isset($roles_mapping[$auth0_role])) {
         $account->addRole($roles_mapping[$auth0_role]);
-      }
-      else {
-        \Drupal::logger('yukon_sso')->alert("Mapping error for SSO role: '{$auth0_role}'. There is no mapping for this role. Account: {$account->getAccountName()}");
       }
     }
   }

--- a/docroot/modules/custom/yukon_sso/yukon_sso.module
+++ b/docroot/modules/custom/yukon_sso/yukon_sso.module
@@ -11,9 +11,60 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_openid_connect_userinfo_save().
  */
 function yukon_sso_openid_connect_userinfo_save($account, $context) {
+
+  // Skip for already existing users. Roles were updated
+  // in hook_openid_connect_pre_authorize() hook.
+  if (!$context['is_new']) {
+    return;
+  }
+
+  // Update user roles.
+  yukon_sso_update_user_role($account, $context);
+}
+
+/**
+ * Implements hook_openid_connect_pre_authorize().
+ */
+function yukon_sso_openid_connect_pre_authorize($account, $context) {
   $roles_mapping = yukon_sso_get_roles_mapping();
 
-  // SSO roles should be updated on each authorization.
+  // For new user allow to log in only if there is SSO role in the response.
+  if (!$account) {
+    if (!empty($context['user_data']['urn:myyukon.ca/groups'])) {
+      foreach ($context['user_data']['urn:myyukon.ca/groups'] as $auth0_role) {
+        if (isset($roles_mapping[$auth0_role])) {
+          return TRUE;
+        }
+      }
+    }
+
+    return FALSE;
+  }
+
+  // Update user roles.
+  yukon_sso_update_user_role($account, $context);
+
+  // Do not allow user without any role to authorize.
+  // Registered user in the system always has default 'authenticated' role, so
+  // we should allow to log in users at least with 2 roles.
+  if (count($account->getRoles()) < 2) {
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+/**
+ * SSO roles should be updated on each authorization.
+ *
+ * @param \Drupal\Core\Session\AccountInterface $account
+ *   User account.
+ * @param array $context
+ *   SSO request response.
+ */
+function yukon_sso_update_user_role(&$account, $context) {
+  $roles_mapping = yukon_sso_get_roles_mapping();
+
   // Delete all SSO user roles.
   foreach ($account->getRoles() as $role) {
     if (in_array($role, $roles_mapping)) {
@@ -39,13 +90,13 @@ function yukon_sso_openid_connect_userinfo_save($account, $context) {
  */
 function yukon_sso_get_roles_mapping(): array {
   return [
-    'web-admin' => 'site_administrator',
-    'web-trans' => 'translator',
-    'web-team' => 'team_administrator',
-    'web-alerts' => 'author_in_page_alerts',
-    'web-pub' => 'publisher',
-    'web-editor' => 'editor',
-    'web-writer' => 'writer',
+    'web-yukon-admin' => 'site_administrator',
+    'web-yukon-trans' => 'translator',
+    'web-yukon-team' => 'team_administrator',
+    'web-yukon-alerts' => 'author_in_page_alerts',
+    'web-yukon-pub' => 'publisher',
+    'web-yukon-editor' => 'editor',
+    'web-yukon-writer' => 'writer',
   ];
 }
 

--- a/docroot/themes/custom/yukonca_glider/src/sass/pages/_index.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/pages/_index.scss
@@ -7,6 +7,7 @@
 @import "department.page";
 @import "campground.page";
 @import "blog.page";
+@import "login.page";
 @import "news_events.page";
 @import "campaign.page";
 @import "node.3154";

--- a/docroot/themes/custom/yukonca_glider/src/sass/pages/_login.page.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/pages/_login.page.scss
@@ -1,0 +1,11 @@
+.path-user {
+  .openid-connect-login-form {
+    .form-submit {
+      @apply bg-blue-200 text-white rounded py-1.5 px-3;
+
+      &:hover {
+        @apply bg-blue-100;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Since #653 won't happen before launch, this merge request bring SSO functionality to the `w3_staging_yukon` branch.

# What's included

- Implements single-sign-on for YG staff
- Role assignment based on group membership

# Notes

Relates to:
- #311
- #521 
- #312 
- #522

Reproduces
- #648 (which was to `master`)

# Deployment steps

1. Roll out the code
2. Composer install
3. Config import
4. Edit `settings.local.php`, if needed

```php
// SSO through MyYukon
$config['openid_connect.settings.generic']['settings'] = [
        'client_id' => '1234',
        'client_secret' => 'ABCD',
        'authorization_endpoint' => 'https://sign-in.service.yukon.ca/authorize',
        'token_endpoint' => 'https://sign-in.service.yukon.ca/oauth/token',
        'userinfo_endpoint' => 'https://sign-in.service.yukon.ca/userinfo'
];
```