### PR TITLE
eServices - Workflow tweaks around unpublishing

### DIFF
--- a/config/default/workflows.workflow.content.yml
+++ b/config/default/workflows.workflow.content.yml
@@ -31,7 +31,7 @@ type_settings:
       label: Archived
       weight: 4
       published: false
-      default_revision: false
+      default_revision: true
     draft:
       label: Draft
       weight: 0

--- a/config/default/workflows.workflow.content.yml
+++ b/config/default/workflows.workflow.content.yml
@@ -67,6 +67,7 @@ type_settings:
     create_new_draft:
       label: 'Create New Draft'
       from:
+        - archived
         - draft
         - published
       to: draft


### PR DESCRIPTION
# What's included

## Archived should be unpublished

When moving content to Archived, the content should no longer be accessible to the pubic.

This was reported as
- #733 

## Allow published content to be unpublished

Allow Archived content to move to the Draft workflow state. This supports editors who want to revoke content that was previously published (e.g. by accident). Previously they had to delete the content.

This was reported as:
- #770

# Deployment instructions

1. Back up the DB
2. Roll out the code
3. Config import `drush config:import`