### PR TITLE
eServices - prod config captured - leading zero on some dates

### DIFF
--- a/config/default/core.date_format.month_date.yml
+++ b/config/default/core.date_format.month_date.yml
@@ -5,4 +5,4 @@ dependencies: {  }
 id: month_date
 label: 'Month Date'
 locked: false
-pattern: 'F d'
+pattern: 'F j'


### PR DESCRIPTION
# What's included

A minor configuration change that was made in prod is captured in code

Closes #754

# Deployment instructions

None, as this change is already in prod.