### PR TITLE
eServices - hotfix for #866

### DIFF
--- a/config/default/core.entity_form_display.node.directory_records_places.default.yml
+++ b/config/default/core.entity_form_display.node.directory_records_places.default.yml
@@ -26,7 +26,6 @@ dependencies:
     - field.field.node.directory_records_places.field_social_sharing
     - field.field.node.directory_records_places.field_statutory_holiday_link
     - field.field.node.directory_records_places.field_street_address
-    - field.field.node.directory_records_places.field_translation_status
     - field.field.node.directory_records_places.field_website
     - field.field.node.directory_records_places.field_yukon_editorial_team
     - node.type.directory_records_places
@@ -441,12 +440,6 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
-  field_translation_status:
-    type: options_buttons
-    weight: 26
-    region: content
-    settings: {  }
     third_party_settings: {  }
   field_website:
     type: linkit


### PR DESCRIPTION
# What's included

Small config change to `core.entity_form_display.node.directory_records_places.default.yml`, removing references to `field_translation_status`, which hasn't landed yet. This problem landed as part of #866.

# Deployment instructions

1. roll out code
2. import configuration `drush config:import`
