### PR TITLE
W3-Mar-14-2025-v1

### DIFF
--- a/config/default/field.field.node.basic_page.field_translation_status.yml
+++ b/config/default/field.field.node.basic_page.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: b4a07c9c-8cac-4792-8a1a-3967f8fc35fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.basic_page
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.basic_page.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: basic_page
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.blog.field_translation_status.yml
+++ b/config/default/field.field.node.blog.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 8d498bc9-3de9-4f7d-b1ba-cd6935b6fa4d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.blog
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.blog.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: blog
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.campaign_page.field_translation_status.yml
+++ b/config/default/field.field.node.campaign_page.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 22836356-9432-407f-b44c-f6b0429488f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.campaign_page
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.campaign_page.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: campaign_page
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.campground_directory_record.field_translation_status.yml
+++ b/config/default/field.field.node.campground_directory_record.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 1f37fd61-5ce1-450b-9a68-33d0c12777e1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.campground_directory_record
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.campground_directory_record.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: campground_directory_record
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.department.field_translation_status.yml
+++ b/config/default/field.field.node.department.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 4a9e68f3-17cf-4cf8-8e53-a6437ccfdab2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.department
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.department.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: department
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.directory_records_places.field_translation_status.yml
+++ b/config/default/field.field.node.directory_records_places.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: f1d722dd-2357-43c0-a2e3-daf77a21ecb1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.directory_records_places
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.directory_records_places.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: directory_records_places
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.documents.field_translation_status.yml
+++ b/config/default/field.field.node.documents.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 705a37a1-9308-44c9-945c-4031ef0009cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.documents
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.documents.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: documents
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.engagement.field_translation_status.yml
+++ b/config/default/field.field.node.engagement.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 679d6d0c-fc9c-4c9b-a2ad-7df98d87b3eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.engagement
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.engagement.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: engagement
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.event.field_translation_status.yml
+++ b/config/default/field.field.node.event.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: eddee480-6bed-4406-9838-236a91e0795b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.event
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.event.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: event
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.homepage.field_translation_status.yml
+++ b/config/default/field.field.node.homepage.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: f1cb4614-9fd8-46bc-abf2-98d25d715be2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.homepage
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.homepage.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: homepage
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.in_page_alert.field_translation_status.yml
+++ b/config/default/field.field.node.in_page_alert.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: c49515f3-160c-4a81-93cc-71ab25ff8931
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.in_page_alert
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.in_page_alert.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: in_page_alert
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.landing_page.field_translation_status.yml
+++ b/config/default/field.field.node.landing_page.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 678dffa4-b999-4f7f-9c26-087d3bb1c2f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.landing_page
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.landing_page.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: landing_page
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.landing_page_level_2.field_translation_status.yml
+++ b/config/default/field.field.node.landing_page_level_2.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: 36a18650-c911-49a2-bfc3-f246be3ab9f7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.landing_page_level_2
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.landing_page_level_2.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: landing_page_level_2
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.multi_step_page.field_translation_status.yml
+++ b/config/default/field.field.node.multi_step_page.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: a8771c8b-4089-4637-9e55-e88e56bcd9f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.multi_step_page
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.multi_step_page.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: multi_step_page
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.news.field_translation_status.yml
+++ b/config/default/field.field.node.news.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: e7f0d6a8-333e-415b-9400-c9bc7eb51988
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.news
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.news.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: news
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.site_wide_alert.field_translation_status.yml
+++ b/config/default/field.field.node.site_wide_alert.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: c3badb09-6cd0-4bc5-9c32-4725b8429d08
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.site_wide_alert
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.site_wide_alert.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: site_wide_alert
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.field.node.topics_page.field_translation_status.yml
+++ b/config/default/field.field.node.topics_page.field_translation_status.yml
@@ -1,0 +1,25 @@
+uuid: d3e9eb88-b1eb-4057-af33-f809a6da8296
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_translation_status
+    - node.type.topics_page
+  module:
+    - options
+    - tmgmt_content
+third_party_settings:
+  tmgmt_content:
+    excluded: false
+id: node.topics_page.field_translation_status
+field_name: field_translation_status
+entity_type: node
+bundle: topics_page
+label: 'Translation status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/default/field.storage.node.field_translation_status.yml
+++ b/config/default/field.storage.node.field_translation_status.yml
@@ -1,0 +1,27 @@
+uuid: 692982e8-0a19-4c8f-b041-f4d723cb5f8d
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_translation_status
+field_name: field_translation_status
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: in_progress
+      label: 'In progress'
+    -
+      value: not_required
+      label: 'Not required'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.routing.yml
+++ b/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.routing.yml
@@ -30,7 +30,7 @@ yukon_w3_custom.content_translation:
     _title: 'Content Translation'
     _controller: '\Drupal\yukon_w3_custom\Controller\ContentTranslationController::content'
   requirements:
-    _permission: 'administer site configuration'
+    _role: 'administrator+translator'
   options:
     access: TRUE
 


### PR DESCRIPTION
# What's included

Two fixes for 
- https://github.com/ytgov/yukon-ca/issues/833

This merge request will address the following: 

Permission to access the admin/content_translation page
- https://github.com/ytgov/yukon-ca/issues/833#issuecomment-2725329170

Missing field (most recently identified in #866)
- https://github.com/ytgov/yukon-ca/pull/866#issuecomment-272534615
- partially undone in #874

`field_translation_status` is required for all content types and that is why we have a couple of config files.

# Deployment instructions

1. Backup database
2. Roll out code
3. Import configuration `drush config:import`
