### PR TITLE
eServices - Undo forced "Generate automatic URL alias" for French

### DIFF
--- a/docroot/modules/custom/yukon_w3_custom/js/yukon_w3_custom.js
+++ b/docroot/modules/custom/yukon_w3_custom/js/yukon_w3_custom.js
@@ -1,9 +1,0 @@
-jQuery("input[value='Soumettre un commentaire (this translation)']").click(function() {
-    if (jQuery(".path-form  .form-checkbox").prop("checked") == false){ 
-        alert("Please Checked Generate automatic URL alias");
-        jQuery(".path-form  .form-checkbox").focus();
-        return false;
-    }
-    
-
-});

--- a/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.libraries.yml
+++ b/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.libraries.yml
@@ -12,7 +12,3 @@ yukon_w3_custom.chart_js:
   js:
     '//code.highcharts.com/highcharts.js': { type: external }
     js/charts.js: {}
-
-yukon_w3_custom.js:
-  js:
-    js/yukon_w3_custom.js: {}

--- a/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.module
+++ b/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.module
@@ -5,7 +5,6 @@
  * Yukon w3 migrate module.
  */
 
-use Drupal\node\NodeInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
@@ -48,9 +47,6 @@ function yukon_w3_custom_form_alter(&$form, FormStateInterface $form_state, $for
     $form['#attached']['library'][] = 'yukon_w3_custom/yukon_w3_custom.css';
   }
   $node = \Drupal::routeMatch()->getParameter('node');
-  if ($node instanceof NodeInterface) {
-    $form['#attached']['library'][] = 'yukon_w3_custom/yukon_w3_custom.js';
-  }
   if ($node instanceof NodeInterface) {
     $query = \Drupal::database()->select('users_field_data', 't');
     $query->fields('t', ['uid', 'name']);


### PR DESCRIPTION
# What's included

Undoes the forced "You must click on 'Generate automatic URL alias'" alert when editing French nodes.

Relates to 
- #796

The alert was originally deployed as part of
- #862

# Notes

Work on #796 remains ongoing. This changes only undoes part of an earlier attempt at fixing the issue, which proved misguided.

# Deployment instructions

1. Roll out the code.
2. Clear cache.