### PR TITLE
eServices - cherry-pick event time fix

### DIFF
--- a/docroot/themes/custom/yukonca_glider/yukonca_glider.theme
+++ b/docroot/themes/custom/yukonca_glider/yukonca_glider.theme
@@ -296,23 +296,31 @@ function yukonca_glider_preprocess_node__event(&$variables) {
 
   $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
   if ($langcode == 'en') {
-    if (date('i', strtotime($node->field_event_start_time->value) == "00")) {
+    if (date('i', strtotime($node->field_event_start_time->value)) == "00") {
       $start_time = date('g a', (strtotime($node->field_event_start_time->value) - 60 * 60 * 7));
-      $end_time = date('g a', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
     }
     else {
       $start_time = date('g:i a', (strtotime($node->field_event_start_time->value) - 60 * 60 * 7));
+    }
+    if (date('i', strtotime($node->field_event_start_time->end_value)) == "00") {
+      $end_time = date('g a', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
+    }
+    else {
       $end_time = date('g:i a', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
     }
   }
   else {
     if (!empty($node->field_event_start_time->value)) {
-      if (date('i', strtotime($node->field_event_start_time->value) == "00")) {
+      if (date('i', strtotime($node->field_event_start_time->value)) == "00") {
         $start_time = date('G \h', (strtotime($node->field_event_start_time->value) - 60 * 60 * 7));
-        $end_time = date('G \h', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
       }
       else {
         $start_time = date('G \h i', (strtotime($node->field_event_start_time->value) - 60 * 60 * 7));
+      }
+      if (date('i', strtotime($node->field_event_start_time->end_value)) == "00") {
+        $end_time = date('G \h', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
+      }
+      else {
         $end_time = date('G \h i', (strtotime($node->field_event_start_time->end_value) - 60 * 60 * 7));
       }
     }


### PR DESCRIPTION
# What's included

Fix for event times only displaying whole hours. With this change, arbitrary minutes can be displayed.

This pull request includes commit 436bb40.

# Notes

This was previously merged in `main_w3_staging` as part of #844.

# Deployment instructions

1. Roll out the code
2. Rebuild the cache
