### PR TITLE
eServices - revise roles workflow

### DIFF
--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -132,6 +132,7 @@ permissions:
   - 'update media'
   - 'use content transition create_new_draft'
   - 'use content transition create_new_draft'
+  - 'use content transition reject_from_review'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use text format full_html'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -168,6 +168,7 @@ permissions:
   - 'use content transition publish'
   - 'use content transition publish_directly'
   - 'use content transition reject'
+  - 'use content transition reject_from_review'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use text format full_html'

--- a/config/default/user.role.site_administrator.yml
+++ b/config/default/user.role.site_administrator.yml
@@ -344,6 +344,7 @@ permissions:
   - 'use content transition publish'
   - 'use content transition publish_directly'
   - 'use content transition reject'
+  - 'use content transition reject_from_review'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use text format full_html'

--- a/config/default/user.role.translator.yml
+++ b/config/default/user.role.translator.yml
@@ -276,6 +276,7 @@ permissions:
   - 'use content transition publish'
   - 'use content transition publish_directly'
   - 'use content transition reject'
+  - 'use content transition reject_from_review'
   - 'use content transition submit_for_publish'
   - 'use content transition submit_for_review'
   - 'use text format full_html'

--- a/config/default/workflows.workflow.content.yml
+++ b/config/default/workflows.workflow.content.yml
@@ -88,12 +88,17 @@ type_settings:
       to: published
       weight: 7
     reject:
-      label: Reject
+      label: 'Reject from publication'
       from:
-        - needs_review
         - ready_to_publish
       to: draft
       weight: 4
+    reject_from_review:
+      label: 'Reject from review'
+      from:
+        - needs_review
+      to: draft
+      weight: -3
     submit_for_publish:
       label: 'Submit for publish'
       from:


### PR DESCRIPTION
# What's included

Changes to workflow and permissions to improve staff experience

- fixes #955 

Specifically:
- Allow Publisher, Translator and Site Admin to use _Reject_ transition
- Allow _Submit for review_ from "Needs review" and "Published"
- Allow _Submit for publish_ from "Ready to publish" and "Published"
- New transition for dealing with Ready for review and Ready for publication, _Reject from review_

# Deployment instructions

- roll out code
- import config `drush config:import`