### PR TITLE
eServices - Changes from prod 2025-10-31 🎃

### DIFF
--- a/config/default/media.settings.yml
+++ b/config/default/media.settings.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: PlWtVQXY5oKYZqCMPXh6SPamXagn5BoZqgAI8EY9WsY
 icon_base_uri: 'public://media-icons/generic'
-iframe_domain: null
+iframe_domain: 'https://yukon.ca'
 oembed_providers_url: 'https://oembed.com/providers.json'
 standalone_url: false


### PR DESCRIPTION
# What's included

## Changes from prod

This merge request attempts to capture changes that were made to configuration in production since the last time we did this, https://github.com/ytgov/yukon-ca/pull/953.

- Capture media iframe setting.
    - This is another candidate for #948, as this change means non-prod sites will try to reference yukon.ca for embedded content.

# Deployment instructions

(Redundant, as these changes are already in prod)