### PR TITLE
eServices - News published date format

### DIFF
--- a/docroot/themes/custom/yukonca_glider/templates/content/node--news--full.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/content/node--news--full.html.twig
@@ -92,7 +92,7 @@
     <footer class="node__meta mb-12 text-gray italic border-0 border-solid border-b border-gray">
       {{ author_picture }}
       <div{{ author_attributes.addClass('node__submitted') }}>
-        {% trans %}Published {% endtrans %} {{ publish_date|date('d/m/Y') }}
+        {% trans %}Published {% endtrans %} {{ publish_date }}
         {{ metadata }}
       </div>
     </footer>

--- a/docroot/themes/custom/yukonca_glider/templates/content/node--news--full.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/content/node--news--full.html.twig
@@ -89,7 +89,7 @@
   {{ title_suffix }}
 
   {% if display_submitted %}
-    <footer class="node__meta mb-12 text-gray italic border-0 border-solid border-b border-gray">
+    <footer class="node__meta mb-12 italic border-0 border-solid border-b border-gray">
       {{ author_picture }}
       <div{{ author_attributes.addClass('node__submitted') }}>
         {% trans %}Published {% endtrans %} {{ publish_date }}

--- a/docroot/themes/custom/yukonca_glider/yukonca_glider.theme
+++ b/docroot/themes/custom/yukonca_glider/yukonca_glider.theme
@@ -280,7 +280,8 @@ function yukonca_glider_preprocess_node__news(&$variables) {
 
   // Validate node creation date and current date.
   $created_time = $source_translation->getCreatedTime();
-  $variables['publish_date'] = $created_time;
+  $date_formatter = \Drupal::service('date.formatter');
+  $variables['publish_date'] = $date_formatter->format($created_time, 'medium_format');
 }
 
 /**


### PR DESCRIPTION
# What's included

This pull request changes the date format for "Published" date of news records.

1. Change the display (what words and numbers are used in what order)
2. Change the colour

Together these fix #974.

## Display

- Old: custom, using "dd/mm/yyyy". E.g. 12/03/2025
- New: site standard, using "Medium format" [1](https://github.com/ytgov/yukon-ca/issues/465#issuecomment-2214549686). E.g. March 12, 2025

The new style also matches the date format what's used on the /news News listings page.

## Colour

Remove the "dark grey" from the date on the News node page.

# Notes

This merge request does not change the `/news` listing page, where a different dark grey is used for the dates.

# Deployment instructions

- Roll out the code
- Rebuild cache
