### PR TITLE
eServices - Change order of /blogs listing

### DIFF
--- a/config/default/views.view.yukon_blog_listing.yml
+++ b/config/default/views.view.yukon_blog_listing.yml
@@ -313,22 +313,21 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        changed:
-          id: changed
+        weight:
+          id: weight
           table: taxonomy_term_field_data
-          field: changed
+          field: weight
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
-          entity_field: changed
-          plugin_id: date
-          order: DESC
+          entity_field: weight
+          plugin_id: standard
+          order: ASC
           expose:
             label: ''
             field_identifier: ''
           exposed: false
-          granularity: second
       arguments: {  }
       filters:
         status:


### PR DESCRIPTION
# What's included

Change the order of the `/blogs` page to match term weight.

This fixes #967 

# Deployment instructions

1. Roll out code
2. Config import