### PR TITLE
eServices - Changes from prod 2026-02-25

### DIFF
--- a/config/default/block.block.yukonca_glider_views_block__facilities_listing_blocks_block_22.yml
+++ b/config/default/block.block.yukonca_glider_views_block__facilities_listing_blocks_block_22.yml
@@ -27,4 +27,4 @@ visibility:
   request_path:
     id: request_path
     negate: false
-    pages: /test-yukon-permanent-art-collection
+    pages: "/test-yukon-permanent-art-collection\r\n/node/29052"

--- a/config/default/language/fr/field.storage.node.field_engagement_status.yml
+++ b/config/default/language/fr/field.storage.node.field_engagement_status.yml
@@ -1,0 +1,10 @@
+settings:
+  allowed_values:
+    -
+      label: 'En cours'
+    -
+      label: Terminée
+    -
+      label: 'En cours avec résultats'
+    -
+      label: 'Terminée avec résultats'

--- a/config/default/language/fr/views.view.engagements.yml
+++ b/config/default/language/fr/views.view.engagements.yml
@@ -10,6 +10,9 @@ display:
         field_engagement_status_value:
           expose:
             label: Statut
+        title:
+          expose:
+            label: 'Trouver une consultation'
       empty:
         area:
           content:

--- a/config/default/language/fr/views.view.news_listing.yml
+++ b/config/default/language/fr/views.view.news_listing.yml
@@ -20,9 +20,6 @@ display:
         field_news_type_target_id:
           expose:
             label: "Type d'actualité"
-        field_featured_content_value:
-          expose:
-            description: ''
   block_news_listing:
     display_options:
       filters:

--- a/config/default/language/fr/views.view.search.yml
+++ b/config/default/language/fr/views.view.search.yml
@@ -39,7 +39,7 @@ display:
       exposed_form:
         options:
           submit_button: Rechercher
-      title: Chercher
+      title: Résultats
       header:
         result:
           content: 'Résultats @start - @end de @total'

--- a/config/default/views.view.engagements.yml
+++ b/config/default/views.view.engagements.yml
@@ -814,6 +814,48 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
+        langcode_1:
+          id: langcode_1
+          table: taxonomy_term_field_data
+          field: langcode
+          relationship: field_engagement_category
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -851,6 +893,17 @@ display:
       display_description: ''
       display_extenders:
         ajax_history: {  }
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
       block_description: 'Engagements pane'
     cache_metadata:
       max-age: -1

--- a/config/default/views.view.news_listing.yml
+++ b/config/default/views.view.news_listing.yml
@@ -2071,6 +2071,48 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
# What's included

## Changes from prod

This merge request attempts to capture changes that were made to configuration in production since the last time we did this, https://github.com/ytgov/yukon-ca/pull/997.

- News view change. Captures the fix for #1001.
- Search translation tweak. Probably related to #929.
- Facilities block config for Permanent Art Collection page
- Translations related to Public Engagements. For #1016.

# Deployment instructions

(Redundant, as these changes are already in prod)