### PR TITLE
eServices - Expose department names in metadata tag

### DIFF
--- a/config/default/metatag.metatag_defaults.node.yml
+++ b/config/default/metatag.metatag_defaults.node.yml
@@ -12,6 +12,7 @@ tags:
   dcterms_date: '[node:bilingual_date_published]'
   dcterms_description: '[node:improved_summary]'
   dcterms_language: '[current-page:bilingual_prefix]'
+  dcterms_publisher: 'Government of Yukon [node:field_department_term_en]'
   dcterms_subject: '[current-page:bilingual_default_value]'
   dcterms_title: '[node:title]'
   description: '[node:field_page_description]'

--- a/docroot/modules/custom/yukon_base/yukon_base.tokens.inc
+++ b/docroot/modules/custom/yukon_base/yukon_base.tokens.inc
@@ -27,6 +27,10 @@ function yukon_base_token_info(): array {
     'name' => t('Metatag: Bilingual Date Published'),
     'description' => t('Bilingual Date Published for use with Metatags'),
   ];
+  $info['tokens']['node']['field_department_term_en'] = [
+    'name' => t('Metatag: Department, always in English'),
+    'description' => t('English value of field_department_term'),
+  ];
 
   return [
     'types' => $info,
@@ -55,6 +59,25 @@ function yukon_base_tokens($type, $tokens, array $data, array $options, Bubbleab
         case 'bilingual_date_published':
           $published_time = $node->getCreatedTime();
           $replacements[$original] = \Drupal::service('date.formatter')->format($published_time, 'custom', 'Y-m-d');
+          break;
+
+        case 'field_department_term_en':
+          if(!$node->hasField('field_department_term')) {
+            break;
+          }
+          // From SO
+          //   https://stackoverflow.com/questions/37122908/drupal-8-get-taxonomy-term-value-in-node
+          //   https://drupal.stackexchange.com/questions/205972/how-do-i-load-taxonomy-terms
+          $term_id = $node->get('field_department_term')->target_id;
+          if(empty($term_id)) {
+            break;
+          }
+          // Load the term with no language context, gets the original.
+          $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($term_id);
+          if(empty($term)){
+            break;
+          }
+          $replacements[$original] = $term->getName();
           break;
       }
     }

--- a/docroot/modules/custom/yukon_base/yukon_base.tokens.inc
+++ b/docroot/modules/custom/yukon_base/yukon_base.tokens.inc
@@ -29,7 +29,7 @@ function yukon_base_token_info(): array {
   ];
   $info['tokens']['node']['field_department_term_en'] = [
     'name' => t('Metatag: Department, always in English'),
-    'description' => t('English value of field_department_term'),
+    'description' => t('English value of field_department_term(s)'),
   ];
 
   return [
@@ -68,16 +68,12 @@ function yukon_base_tokens($type, $tokens, array $data, array $options, Bubbleab
           // From SO
           //   https://stackoverflow.com/questions/37122908/drupal-8-get-taxonomy-term-value-in-node
           //   https://drupal.stackexchange.com/questions/205972/how-do-i-load-taxonomy-terms
-          $term_id = $node->get('field_department_term')->target_id;
-          if(empty($term_id)) {
+          $terms = $node->get('field_department_term')->referencedEntities();
+          if(empty($terms)) {
             break;
           }
-          // Load the term with no language context, gets the original.
-          $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($term_id);
-          if(empty($term)){
-            break;
-          }
-          $replacements[$original] = $term->getName();
+          $departments = array_map(fn($term): string => $term->getName(), $terms);
+          $replacements[$original] = implode(', ',  $departments);
           break;
       }
     }


### PR DESCRIPTION
# What's included

Expose Department name(s) in metadata tag.

Specifically, the `dcterm` `publisher` value.

```html
<meta name="dcterms.publisher" content="Government of Yukon Community Services"/>
```

This is done by exposing a new token `[node:field_department_term_en]`, which is then used by the Metatag module.

This should fix #1020.

# Notes

While most nodes have a single Department, the field can have up to 3 values. This token combines them all, joining with ", ".

# Deployment instructions

1. Roll out code
2. Import updated configuration (`config/default/metatag.metatag_defaults.node.yml`)
3. Rebuild cache