### PR TITLE
eServices - News year filter

### DIFF
--- a/docroot/modules/custom/yukon_w3_custom/src/Plugin/views/filter/YearFIlter.php
+++ b/docroot/modules/custom/yukon_w3_custom/src/Plugin/views/filter/YearFIlter.php
@@ -8,6 +8,10 @@ use Drupal\views\Plugin\views\filter\FilterPluginBase;
 /**
  * Filters nodes by year of publish date.
  *
+ * Start year defaults to 2022, can be set in settings.php
+ *
+ *    $settings['yukon_w3_custom_view_filter_year']['start'] = 2023;
+ *
  * @ViewsFilter("year_filter")
  */
 class YearFIlter extends FilterPluginBase {
@@ -23,10 +27,13 @@ class YearFIlter extends FilterPluginBase {
    * {@inheritdoc}
    */
   protected function valueForm(&$form, FormStateInterface $form_state) {
+    $settings = \Drupal::service('settings');
+    $start_year = intval($settings->get('yukon_w3_custom_view_filter_year', ['start' => 2022])['start']);
+
     $current_year = date('Y');
     $options = [];
 
-    for ($year = 2022; $year <= $current_year; $year++) {
+    for ($year = $start_year; $year <= $current_year; $year++) {
       $options[$year] = $year;
     }
 

--- a/docroot/modules/custom/yukon_w3_custom/src/Plugin/views/filter/YearFIlter.php
+++ b/docroot/modules/custom/yukon_w3_custom/src/Plugin/views/filter/YearFIlter.php
@@ -26,7 +26,7 @@ class YearFIlter extends FilterPluginBase {
     $current_year = date('Y');
     $options = [];
 
-    for ($year = 2018; $year <= $current_year; $year++) {
+    for ($year = 2022; $year <= $current_year; $year++) {
       $options[$year] = $year;
     }
 


### PR DESCRIPTION
# What's included

Change the News filter form so that the start year is 2022 instead of 2018. This fixes 
- #1026 

This change affects the date section of the "Filter by" form on `/news`. E.G. https://yukon.ca/news

In the future, the start year can be updated in `settings.php` (or equivalent), like:

```php
$settings['yukon_w3_custom_view_filter_year']['start'] = 2023;
```

# Deployment instructions

1. Roll out the code `git pull`
2. Regenerate cache `drush cr`