### PR TITLE
eServices - Changes from prod 2026-04-01

### DIFF
--- a/config/default/core.entity_view_display.node.homepage.default.yml
+++ b/config/default/core.entity_view_display.node.homepage.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.homepage.field_publisher
     - field.field.node.homepage.field_secondary_item_blocks
     - field.field.node.homepage.field_tertiary_item_blocks
+    - field.field.node.homepage.field_translation_status
     - field.field.node.homepage.field_yukon_editorial_team
     - node.type.homepage
   module:
@@ -29,20 +30,12 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    weight: -20
-    region: content
-  field_editor_publisher:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 11
+    weight: 0
     region: content
   field_image_gallery:
     type: entity_reference_revisions_entity_view
@@ -51,7 +44,7 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 4
+    weight: 5
     region: content
   field_primary_item_blocks:
     type: entity_reference_entity_view
@@ -60,15 +53,7 @@ content:
       view_mode: primary_item_block
       link: false
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_publisher:
-    type: entity_reference_label
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    weight: 10
+    weight: 2
     region: content
   field_secondary_item_blocks:
     type: entity_reference_entity_view
@@ -77,7 +62,7 @@ content:
       view_mode: secondary_item_block
       link: false
     third_party_settings: {  }
-    weight: 2
+    weight: 3
     region: content
   field_tertiary_item_blocks:
     type: entity_reference_entity_view
@@ -86,13 +71,16 @@ content:
       view_mode: tertiary_item_blocks
       link: false
     third_party_settings: {  }
-    weight: 3
+    weight: 4
     region: content
 hidden:
   addtoany: true
   field_department_term: true
+  field_editor_publisher: true
   field_meta_tags: true
   field_page_description: true
+  field_publisher: true
+  field_translation_status: true
   field_yukon_editorial_team: true
   langcode: true
   links: true

--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -3,6 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.media_directories_editor_browser
+    - entity_browser.browser.media_directories_modal
+    - entity_browser.browser.media_directories_overview
     - filter.format.full_html
     - media.type.audio
     - media.type.document
@@ -28,9 +31,11 @@ dependencies:
   module:
     - content_moderation
     - contextual
+    - entity_browser
     - filter
     - linkchecker
     - media
+    - media_directories_ui
     - node
     - path
     - system
@@ -48,7 +53,11 @@ permissions:
   - 'access broken links report'
   - 'access content overview'
   - 'access contextual links'
+  - 'access media directories ui browser'
   - 'access media overview'
+  - 'access media_directories_editor_browser entity browser pages'
+  - 'access media_directories_modal entity browser pages'
+  - 'access media_directories_overview entity browser pages'
   - 'access own broken links report'
   - 'access site in maintenance mode'
   - 'access toolbar'

--- a/config/default/views.view.in_page_alerts.yml
+++ b/config/default/views.view.in_page_alerts.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
     - node.type.in_page_alert
   module:
     - node
@@ -189,7 +188,7 @@ display:
         type: 'entity:node'
         options:
           relationship: none
-          view_mode: teaser
+          view_mode: default
       query:
         type: views_query
         options:
@@ -221,6 +220,17 @@ display:
       rendering_language: '***LANGUAGE_language_interface***'
       display_extenders:
         ajax_history: {  }
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
# What's included

## Changes from prod

This merge request attempts to capture changes that were made to configuration in production since the last time we did this, https://github.com/ytgov/yukon-ca/pull/1017.

- Update In-Page Alert View. Captures the fix for #1036.
- Remove Editor Publisher field from homepage display. Captures the fix for #1032
- Change permissions for Editor role, mostly around media directories. Possibly related to #701

# Deployment instructions

(Redundant, as these changes are already in prod)