### PR TITLE
eServices - Increase space between footer links

### DIFF
--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
@@ -34,6 +34,7 @@
 
     &.menu li {
       @apply pt-0;
+      @apply my-1;
 
       a {
         @apply text-white leading-[23px] font-medium;

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
@@ -37,7 +37,7 @@
       @apply my-1;
 
       a {
-        @apply text-white leading-[23px] font-medium;
+        @apply text-white leading-[23px];
       }
     }
   }


### PR DESCRIPTION
# What's included

A minor theme style change to increase the spacing around footer links. This is to fix 
- #1052.

# Deployment instructions

1. roll out code
2. rebuild theme

```
npm --prefix docroot/themes/custom/yukonca_glider i
npm --prefix docroot/themes/custom/yukonca_glider run build
```