### PR TITLE
eServices - Translate News Listings month and year "all" label

### DIFF
--- a/config/default/language/fr/views.view.news_listing.yml
+++ b/config/default/language/fr/views.view.news_listing.yml
@@ -20,6 +20,18 @@ display:
         field_news_type_target_id:
           expose:
             label: "Type d'actualité"
+      exposed_form:
+        options:
+          bef:
+            filter:
+              month_filter:
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: '- Tout -|- Mois -'
+              year_filter:
+                advanced:
+                  rewrite:
+                    filter_rewrite_values: '- Tout -|- Année -'
   block_news_listing:
     display_options:
       filters:


### PR DESCRIPTION
# What's included

Translate the " Any " label for Month and Year on the News Listing view filter.

- https://github.com/ytgov/yukon-ca/issues/1075

# Deployment instructions

1. Roll out the code
2. Config import (for the `news_listing`)
3. Rebuild cache