### PR TITLE
Kellett - refs #1045: fix prev/next button visibility when landing on multistep page via hash url

### DIFF
--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/tabs/js/tabs.js
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/tabs/js/tabs.js
@@ -47,6 +47,16 @@
         if (winLocation.hash.substr(0, 1) === '#') {
           $(`a[data-bs-toggle="tab"][data-bs-target="${winLocation.hash}"]`).tab('show');
         }
+        // Set initial prev/next button visibility based on which tab is active
+        // after any hash-based navigation. Without this, the Previous button
+        // stays hidden when landing directly on a non-first step via URL.
+        $('.pills-arrow .btn-links').removeClass('hide');
+        if ($('.nav-pills .nav-item:first-child a').hasClass('active')) {
+          $('.pills-arrow .prev-step.btn-links').addClass('hide');
+        }
+        if ($('.nav-pills .nav-item:last-child a').hasClass('active')) {
+          $('.pills-arrow .next-step.btn-links').addClass('hide');
+        }
       });
 
       $(once('changeWindowHash', 'a[data-bs-toggle="tab"]', context)).on('shown.bs.tab', (e) => {


### PR DESCRIPTION
### What's Included

Fixes #1045 

Exactly what's in the title - a fix to the Javascript handling the multi-step page navigation so it properly checks and sets button visibility on page load.

### Deployment Steps

- Deploy code
- Rebuild cache