### PR TITLE
Kellett - refs #964: visual inline view issue when comparing revisions

### DIFF
--- a/docroot/sites/development.services.yml
+++ b/docroot/sites/development.services.yml
@@ -14,6 +14,10 @@
 # sites/default/default.services.yml or from core/core.services.yml file.
 parameters:
   http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+    cache: false
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/tabs/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/tabs/scss/styles.scss
@@ -60,3 +60,19 @@
     }
   }
 }
+
+// Visual Inline diff view: tab panes have no IDs (stripped by diff module),
+// so Bootstrap tab switching doesn't work. Show all panes stacked and hide
+// the non-functional navigation.
+.diff-responsive-table-wrapper {
+  .tab-content .tab-pane {
+    display: block !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+
+  .pills-arrow,
+  .nav-pills {
+    @apply hidden;
+  }
+}


### PR DESCRIPTION
### What's Included

Fixes #964 

Updated the CSS for the tabs organism to forcefully unroll the tabs when the content is wrapped in the diff view (.diff-responsive-table-wrapper) element. When using the visual inline mode for comparing revisions, this allows all tab content to be seen without issues.

Note that this also includes a commit that enables debug mode for twig templates in the development services file.

### Deployment Steps

- Deploy code
- Rebuild caches