### PR TITLE
Kellett - refs #1090: remove aurora graphics and unify footer colour

### DIFF
--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/pattern-footer.html.twig
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/pattern-footer.html.twig
@@ -1,4 +1,4 @@
-<footer id="footer" class="footer bg-eden max-w-none text-white">
+<footer id="footer" class="footer bg-tiber max-w-none text-white">
   <div class="footer-left relative overflow-hidden py-0 px-1">
     <div class="container-lg footer-logos pt-9 pb-9">
       <a href="/">
@@ -6,7 +6,7 @@
       </a>
     </div>
   </div>
-  <div class="footer-right bg-tiber">
+  <div class="footer-right">
     <div class="container-lg md:flex md:items-start md:justify-between">
       <div class="footer__menus text-base md:flex md:w-auto pt-4">{{ menus }}</div>
       <div class="footer__legal font-light md:w-auto text-sm flex leading-12 ml-1">

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/footer/scss/styles.scss
@@ -1,11 +1,4 @@
 .footer-left {
-  @apply after:content-[""] after:top-0 after:absolute after:bg-no-repeat after:w-11/12 after:h-52 after:bg-full after:right-[-40%];
-  @apply md:after:top-[-30px] md:after:w-8.5/12 md:after:right-[-20%];
-
-  &:after {
-    background-image: url("/themes/custom/yukonca_glider/images/svg/Aurora-main.svg");
-  }
-
   .footer-logos .region-footer-logo {
     @apply min-h-[75px];
   }

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/hero/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/hero/scss/styles.scss
@@ -1,20 +1,6 @@
 @import "src/sass/core";
 
 .hero {
-  &::before {
-    @apply block;
-    @apply content-[""];
-    @apply block;
-    @apply absolute;
-    @apply -top-2.5 md:top-auto;
-    @apply -right-[125px] md:-right-[300px];
-    @apply w-[350px] md:w-2/3;
-    @apply h-[135px];
-    @apply bg-no-repeat;
-    @apply bg-contain md:bg-cover;
-    background-image: url(../../../../../images/svg/Aurora-main.svg);
-  }
-
   img {
     @apply w-auto h-[85px] md:h-[120px];
   }

--- a/docroot/themes/custom/yukonca_glider/templates/blocks/block--page-feedback-webform.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/blocks/block--page-feedback-webform.html.twig
@@ -33,15 +33,6 @@
   ]
 %}
 
-{% if content_type == "basic_page" or content_type == "topics_page" or content_type == "news" or content_type == "multi_step_page" %}
-    <span class="aurora--mini"></span>
-
-{% endif %}
-
-{% if current_url == "/blogs" %}
-    <span class="aurora--mini"></span>
-
-{% endif %}
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if label %}

--- a/docroot/themes/custom/yukonca_glider/templates/content/node--blog--full.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/content/node--blog--full.html.twig
@@ -107,5 +107,4 @@
   <div{{ content_attributes.addClass('node__content') }}>
     {{ content }}
   </div>
-  <span class="aurora--mini"></span>
 </article>

--- a/docroot/themes/custom/yukonca_glider/templates/content/node--engagement.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/content/node--engagement.html.twig
@@ -146,5 +146,3 @@
     {% endif %}
 
 </article>
-
-<span class="aurora--mini"></span>

--- a/docroot/themes/custom/yukonca_glider/templates/layout/page--front.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/layout/page--front.html.twig
@@ -67,10 +67,6 @@
 
   {{ page.help }}
 
-  <div class="aurora-town">
-    <span class="aurora--main"></span>
-  </div>
-
   <main role="main" class="container-lg">
     <a id="main-content" tabindex="-1"></a>
     {# link is in html.html.twig #}

--- a/docroot/themes/custom/yukonca_glider/templates/layout/page--node--1028.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/layout/page--node--1028.html.twig
@@ -78,12 +78,6 @@
 				variant: 'image',
 			})
 		}}
-	{% else %}
-		{% if content_type != "news" %}
-			<div class="aurora-town {{ content_type }}">
-				<span class="aurora--main"></span>
-			</div>
-		{% endif %}
 	{% endif %}
 
 	{{ page.highlighted }}

--- a/docroot/themes/custom/yukonca_glider/templates/layout/page--node--blog.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/layout/page--node--blog.html.twig
@@ -66,10 +66,6 @@
 
   {{ page.help }}
 
-  <div class="aurora-town">
-    <span class="aurora--main"></span>
-  </div>
-
   <main role="main" class="container-lg grow">
       {{ page.breadcrumb }}
     <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}

--- a/docroot/themes/custom/yukonca_glider/templates/layout/page.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/layout/page.html.twig
@@ -95,12 +95,6 @@
           </div>
         </div>
     </div>
-  {% else %}
-    {% if content_type != "news" and content_type != "documents" and content_type != 'directory_records_places' and content_type != 'in_page_alert' and current_path != '/documents' and current_path != '/forms' %}
-        <div class="aurora-town {{ content_type }}">
-          <span class="aurora--main"></span>
-        </div>
-    {% endif %}
   {% endif %}
 
 


### PR DESCRIPTION
### What's Included

Refs #1090

Four branding/design changes consolidated from Jira tickets YCAROADMAP-114, 115, 116, and 117:

- **YCAROADMAP-115**: Unify footer to a single background colour — changed footer container from `bg-eden` to `bg-tiber`, removing the now-redundant `bg-tiber` from the inner `footer-right` div
- **YCAROADMAP-116**: Remove aurora background image from footer — removed `::after` pseudo-element and `Aurora-main.svg` reference from `.footer-left` SCSS
- **YCAROADMAP-114**: Remove aurora graphic from header on all pages — removed `aurora-town`/`aurora--main` markup from `page.html.twig`, `page--front.html.twig`, `page--node--blog.html.twig`, `page--node--1028.html.twig`, and the hero organism SCSS `::before` pseudo-element
- **YCAROADMAP-117**: Remove aurora--mini graphic — removed `aurora--mini` spans from the page feedback webform block, blog post template, and engagement page template. Note: also removed from blog and engagement templates (not explicitly mentioned in the Jira ticket) on the basis that the instruction was to remove aurora from all pages — please confirm or flag for revert if this is out of scope

### Deployment Steps

- Deploy code
- Rebuild caches