### PR TITLE
Kellett - refs #1083: multistep page restrict number of steps

### DIFF
--- a/docroot/modules/custom/yukon_base/yukon_base.module
+++ b/docroot/modules/custom/yukon_base/yukon_base.module
@@ -6,6 +6,32 @@
  */
 
 /**
+ * Implements hook_form_alter().
+ */
+function yukon_base_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  if (!in_array($form_id, ['node_multi_step_page_form', 'node_multi_step_page_edit_form'])) {
+    return;
+  }
+
+  if (!isset($form['field_paragraphs']['widget'])) {
+    return;
+  }
+
+  $max_steps = 6;
+
+  $item_count = count(array_filter(
+    array_keys($form['field_paragraphs']['widget']),
+    fn($key) => is_int($key)
+  ));
+
+  $form['field_paragraphs']['widget']['#cardinality'] = max($item_count, $max_steps);
+
+  if ($item_count >= $max_steps && isset($form['field_paragraphs']['widget']['add_more'])) {
+    $form['field_paragraphs']['widget']['add_more']['#access'] = FALSE;
+  }
+}
+
+/**
  * Implements hook_views_data_alter().
  */
 function yukon_base_views_data_alter(array &$data) {


### PR DESCRIPTION
### What's Included

Fixes #1083

- Adds a form alter in `yukon_base` that caps the number of steps on multi-step page nodes at 6
- For the two existing nodes that already have 7 steps, the cap is set dynamically to the current count, allowing edits and removals but preventing further additions — see issue #1083 for details

### Deployment Steps

- Deploy code
- Rebuild caches