### PR TITLE
Acro - feat (Matomo, Search): Add Matomo heartbeat monitor to tracked pages

### DIFF
--- a/config/default/matomo.settings.yml
+++ b/config/default/matomo.settings.yml
@@ -52,7 +52,7 @@ custom:
       scope: visit
 codesnippet:
   before: ''
-  after: ''
+  after: "_paq.push(['enableHeartBeatTimer', 15]);"
 translation_set: false
 disable_tracking: false
 cache: false


### PR DESCRIPTION
# What's included

Enable [heartbeat monitoring](https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page) in Matomo for tracked pages.

This allows Matomo to accurately track the duration of a page view when its the last page a user visits. Useful for tracking successful search conversions.

Related to:
- #1107 

# Deployment instructions

1. Roll out code
2. Config import