### PR TITLE
Kellett - refs #1113: department page expand and collapse icons not appearing correctly

### DIFF
--- a/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
@@ -3680,11 +3680,11 @@ h1#heading{
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
-.yukon-accordion .yukon-accordion__expand svg, .yukon-accordion .yukon-accordion__collapse svg{
+.yukon-accordion .yukon-accordion__expand i, .yukon-accordion .yukon-accordion__collapse i{
   --tw-text-opacity: 1;
   color: rgb(0 129 144 / var(--tw-text-opacity));
 }
-.yukon-accordion .yukon-accordion__expand:hover svg, .yukon-accordion .yukon-accordion__collapse:hover svg{
+.yukon-accordion .yukon-accordion__expand:hover i, .yukon-accordion .yukon-accordion__collapse:hover i{
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }

--- a/docroot/themes/custom/yukonca_glider/src/sass/base/partials/_accordion.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/base/partials/_accordion.scss
@@ -13,12 +13,12 @@
 	& &__collapse {
 		@apply bg-transparent py-1.5 px-5 rounded-[100px] h-8 hover:text-white hover:bg-blue-600 text-sm leading-none transition-all duration-300 ease-in-out;
 
-		svg {
+		i {
 			@apply text-blue-icon;
 		}
 
 		&:hover {
-			svg {
+			i {
 				@apply text-white;
 			}
 		}

--- a/docroot/themes/custom/yukonca_glider/templates/field/field--node--field-add-branch--department.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/field/field--node--field-add-branch--department.html.twig
@@ -49,10 +49,10 @@
 <div class="yukon-accordion">
     <div class="yukon-accordion__buttons">
       <button class="yukon-accordion__expand" data-once="expand-all">
-        <svg class="svg-inline--fa fa-square-plus" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="square-plus" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M384 32C419.3 32 448 60.65 448 96V416C448 451.3 419.3 480 384 480H64C28.65 480 0 451.3 0 416V96C0 60.65 28.65 32 64 32H384zM224 368C237.3 368 248 357.3 248 344V280H312C325.3 280 336 269.3 336 256C336 242.7 325.3 232 312 232H248V168C248 154.7 237.3 144 224 144C210.7 144 200 154.7 200 168V232H136C122.7 232 112 242.7 112 256C112 269.3 122.7 280 136 280H200V344C200 357.3 210.7 368 224 368z"></path></svg> {{ 'Expand all'|t }}
+        <i class="fas fa-square-plus" aria-hidden="true"></i> {{ 'Expand all'|t }}
       </button>
       <button class="yukon-accordion__collapse" data-once="collapse-all">
-        <svg class="svg-inline--fa fa-square-minus" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="square-minus" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" data-fa-i2svg=""><path fill="currentColor" d="M384 32C419.3 32 448 60.65 448 96V416C448 451.3 419.3 480 384 480H64C28.65 480 0 451.3 0 416V96C0 60.65 28.65 32 64 32H384zM136 232C122.7 232 112 242.7 112 256C112 269.3 122.7 280 136 280H312C325.3 280 336 269.3 336 256C336 242.7 325.3 232 312 232H136z"></path></svg> {{ 'Collapse all'|t }}
+        <i class="fas fa-square-minus" aria-hidden="true"></i> {{ 'Collapse all'|t }}
       </button>
     </div>
   </div>


### PR DESCRIPTION
## What's Included

Refs #1113

- Replaced hardcoded FontAwesome SVG icon markup in the department accordion expand/collapse buttons with `<i>` tags, matching the FontAwesome module's `webfonts` rendering method — the old inline SVG markup relied on sizing CSS that FontAwesome's JS/SVG method used to inject, which stopped being loaded after the module was switched to `webfonts` (#1084), leaving the icons unconstrained/oversized
- Updated `_accordion.scss` icon colour rules to target `i` instead of `svg`
- Confirmed no other templates contain hardcoded FontAwesome SVG markup dependent on the old method

## Deployment Steps

- Deploy code
- Rebuild caches