### PR TITLE
Kellett - refs #1119: Campground page - filters missing on mobile 

### DIFF
--- a/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
@@ -7448,7 +7448,7 @@ aside .filters form .form-item .form-item{
   line-height: 1.1;
 }
 @media (max-width: 767.98px) {
-  .page-node-type-basic-page aside:not(:has(#block-exposedform-news)){
+  .page-node-type-basic-page aside:not(:has(.views-exposed-form)){
     display: none;
   }
 }

--- a/docroot/themes/custom/yukonca_glider/src/sass/pages/_basic.page.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/pages/_basic.page.scss
@@ -2,23 +2,23 @@
     h3 {
         @apply text-[22px] leading-1.1 mt-3.75 pt-5;
     }
-    
-    aside:not(:has(#block-exposedform-news)) {
+
+    aside:not(:has(.views-exposed-form)) {
         @include media-breakpoint-down(md) {
             @apply hidden;
         }
     }
-    
+
     .region-content {
         ul,
         ol {
             @apply pl-12;
-            
+
             li {
                 @apply pl-2.5;
             }
         }
-        
+
         ul {
             @apply list-disc;
         }
@@ -32,7 +32,7 @@ main {
 		.layout-content {
 			.region-content {
 				@apply pt-0 pb-8 relative;
-				
+
 				table {
                     @apply border border-gray-600 w-full mb-6;
 
@@ -44,7 +44,7 @@ main {
                         }
                     }
 				}
-				
+
 				.block-goy-wildfire-low-bandwidth {
 				    .wildfire-container {
                         label {
@@ -52,18 +52,18 @@ main {
                         }
                     }
 				}
-				
+
 				#block-yukonca-glider-arrivalsblock,
 				#block-yukonca-glider-arrivalsdeparturesblock {
                     table {
                         &[data-striping="1"] {
     						@apply border-0;
                             caption-side: top;
-                            
+
                             caption {
     							@apply text-black-light
                             }
-                            
+
                             thead {
                                 tr {
                                     th {
@@ -71,24 +71,24 @@ main {
                                     }
                                 }
                             }
-                            
+
                             tbody {
                                 tr {
                                     &:nth-child(odd) {
     									@apply bg-gray-100;
                                     }
-                                    
+
                                     &:hover {
     									@apply bg-[#F0F0F0];
                                     }
-                                    
+
                                     td {
     									@apply border-0 p-2 leading-6 align-top border-t-1 border-gray-400;
-    									
+
     									&.temperature {
     									    @apply text-right;
     									}
-    									
+
     									&.flight-status-problem {
     									    @apply text-[#800]
     									}
@@ -98,13 +98,13 @@ main {
                         }
                     }
                 }
-				
+
 				// .media {
 				//     img {
 				//         @apply w-[300px];
 				//     }
 				// }
-				
+
 				// .field--name-field-image {
 				//     @apply absolute right-0 ml-[100px] mb-[50px];
 


### PR DESCRIPTION
## What's included
Fixes: #1119 

A SCSS rule was set to hide the entire sidebar on mobile display for basic pages with the exception of those containing the News filter block.
``` css
.page-node-type-basic-page {
  ...
    aside:not(:has(#block-exposedform-news)) {
        @include media-breakpoint-down(md) {
            @apply hidden;
        }
    }
}
```
This seems to have been put in place in order to hide the sidebar navigation menu on mobile.

This also affects other filter block that are configured to display on other basic page nodes:
- Events
- Places
- Back country campgrounds

I changed the CSS rule to `aside:not(:has(.views-exposed-form)) {`. It still does the job of hiding the sidebar on mobile unless an exposed filter block is present for that page.

## Deployment Steps

1. Deploy code
2. Clear caches: `drush cr` 
