### PR TITLE
Kellett - refs #1030: Fix duplicate French facilities listings

### DIFF
--- a/config/default/views.view.facilities_listing_blocks.yml
+++ b/config/default/views.view.facilities_listing_blocks.yml
@@ -1900,6 +1900,48 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        langcode_1:
+          id: langcode_1
+          table: paragraphs_item_field_data
+          field: langcode
+          relationship: field_places_record_type
+          group_type: group
+          admin_label: ''
+          entity_type: paragraph
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2285,6 +2327,48 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        langcode_1:
+          id: langcode_1
+          table: paragraphs_item_field_data
+          field: langcode
+          relationship: field_places_record_type
+          group_type: group
+          admin_label: ''
+          entity_type: paragraph
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
@@ -2293,8 +2377,20 @@ display:
         filters: false
         filter_groups: false
       display_description: ''
+      rendering_language: '***LANGUAGE_entity_translation***'
       display_extenders:
         ajax_history: {  }
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
## What's Included

Facilities listings blocks (Views: `facilities_listing_blocks`) were showing duplicate entries on French pages for the Continuing care and Community care displays. The join to the paragraph reference field (`field_places_record_type`) didn't constrain the paragraph's own translation language, so any paragraph that had been individually translated into French produced two joined rows for the same node (one per paragraph language). Added a "Paragraph: Translation language (= Interface text language selected for page)" filter, via the `field_places_record_type` relationship, to both the Continuing care and Community care displays, restricting the join to the current interface language and eliminating the duplicates.

Note: while testing, we found a separate, pre-existing issue where at least one node's French translation is missing a value for the "Places record type" paragraph reference field entirely, causing it to be silently absent from the French listing (not caused by this fix, and not addressed here) - refs #1030.

## Deployment Steps

- Run `drush config:import` (or equivalent deployment config import step) to pick up the updated `views.view.facilities_listing_blocks` config.
- No database updates or cache-only changes required beyond the standard config import.