### PR TITLE
Kellett - refs #1105: Add off-site link icon

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -174,6 +174,7 @@ module:
   yukon_sso: 0
   yukon_taxonomy: 0
   yukon_w3_custom: 0
+  extlink: 1
   pathauto: 1
   selective_better_exposed_filters: 1
   cshs_menu_link: 5

--- a/config/default/extlink.settings.yml
+++ b/config/default/extlink.settings.yml
@@ -1,0 +1,27 @@
+_core:
+  default_config_hash: vOaSYBgSyTzn8_p0MSY8B-ygp9V0Nc6qnX0vy9KYGeo
+extlink_use_external_js_file: false
+extlink_exclude_admin_routes: false
+extlink_target: false
+extlink_target_no_override: false
+extlink_nofollow: false
+extlink_noreferrer: true
+extlink_follow_no_override: false
+extlink_subdomains: true
+extlink_alert: false
+extlink_alert_text: 'This link will take you to an external web site. We are not responsible for their content.'
+extlink_exclude: ''
+extlink_include: ''
+extlink_class: ext
+extlink_label: '(opens an off-site link)'
+extlink_img_class: false
+extlink_css_exclude: '#header a, #footer a, .social-link a'
+extlink_css_explicit: ''
+extlink_mailto_class: mailto
+extlink_mailto_label: '(link sends email)'
+extlink_use_font_awesome: true
+extlink_font_awesome_classes:
+  links: 'fas fa-up-right-from-square'
+  mailto: 'fas fa-envelope'
+extlink_icon_placement: append
+whitelisted_domains: {  }

--- a/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
@@ -5132,6 +5132,15 @@ select{
   padding-right: 12px;
 }
 
+/**
+ * The extlink module's own extlink.css sets `padding-left` on `extlink i`,
+ * which never matches the `<span class="fa-ext extlink">` markup it
+ * actually injects in Font Awesome mode. Re-apply the padding here.
+ */
+.extlink {
+  padding-left: 0.2em;
+}
+
 /*
 * Include here Drupal Blocks
 */

--- a/docroot/themes/custom/yukonca_glider/src/sass/drupal/elements/_extlink.element.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/drupal/elements/_extlink.element.scss
@@ -1,0 +1,8 @@
+/**
+ * The extlink module's own extlink.css sets `padding-left` on `extlink i`,
+ * which never matches the `<span class="fa-ext extlink">` markup it
+ * actually injects in Font Awesome mode. Re-apply the padding here.
+ */
+.extlink {
+  padding-left: 0.2em;
+}

--- a/docroot/themes/custom/yukonca_glider/src/sass/drupal/elements/_index.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/drupal/elements/_index.scss
@@ -3,3 +3,4 @@
 */
 
 @import "default.element";
+@import "extlink.element";


### PR DESCRIPTION
## What's Included

- Enables `drupal/extlink` and configures it to append a Font Awesome icon (`fas fa-up-right-from-square`) after any link whose hostname differs from yukon.ca — this covers new-tab and same-tab links alike, since detection is based on hostname, not the `target` attribute.
- No new-tab forcing (`extlink_target: false`) and no interstitial popup (`extlink_alert: false`) — visual indicator only, per the issue.
- Icon is excluded from the header, footer, and social-icons component (`extlink_css_exclude: '#header a, #footer a, .social-link a'`) so existing nav/social iconography isn't doubled up.
- Adds a small theme override (`_extlink.element.scss`) fixing a bug in extlink's own bundled CSS: its `extlink i { padding-left: 0.2em; }` rule targets a nonexistent `<extlink>` element and never applies to the actual injected `<span class="extlink">` markup, so the icon rendered with no left padding.

## Deployment Steps

1. Deploy code.
2. Run `drush deploy` (or `drush cim` + `drush cr`) to import `core.extension.yml` and `extlink.settings.yml`, enabling the extlink module and applying its configuration.
3. Verify theme assets are rebuilt/deployed (compiled `dist/css/styles.min.css` is included in this PR, no separate build step needed on the target environment).