### PR TITLE
Kellett - chore: export simple_sitemap form display settings

### DIFF
--- a/config/default/core.entity_form_display.node.basic_page.default.yml
+++ b/config/default/core.entity_form_display.node.basic_page.default.yml
@@ -375,6 +375,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 10

--- a/config/default/core.entity_form_display.node.blog.default.yml
+++ b/config/default/core.entity_form_display.node.blog.default.yml
@@ -217,6 +217,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 13

--- a/config/default/core.entity_form_display.node.campaign_page.default.yml
+++ b/config/default/core.entity_form_display.node.campaign_page.default.yml
@@ -529,6 +529,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 18

--- a/config/default/core.entity_form_display.node.campground_directory_record.default.yml
+++ b/config/default/core.entity_form_display.node.campground_directory_record.default.yml
@@ -712,6 +712,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 22

--- a/config/default/core.entity_form_display.node.department.default.yml
+++ b/config/default/core.entity_form_display.node.department.default.yml
@@ -407,6 +407,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 19

--- a/config/default/core.entity_form_display.node.directory_records_places.default.yml
+++ b/config/default/core.entity_form_display.node.directory_records_places.default.yml
@@ -533,6 +533,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 18

--- a/config/default/core.entity_form_display.node.documents.default.yml
+++ b/config/default/core.entity_form_display.node.documents.default.yml
@@ -211,6 +211,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 10

--- a/config/default/core.entity_form_display.node.engagement.default.yml
+++ b/config/default/core.entity_form_display.node.engagement.default.yml
@@ -288,6 +288,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 13

--- a/config/default/core.entity_form_display.node.event.default.yml
+++ b/config/default/core.entity_form_display.node.event.default.yml
@@ -411,6 +411,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 15

--- a/config/default/core.entity_form_display.node.homepage.default.yml
+++ b/config/default/core.entity_form_display.node.homepage.default.yml
@@ -203,6 +203,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 17

--- a/config/default/core.entity_form_display.node.in_page_alert.default.yml
+++ b/config/default/core.entity_form_display.node.in_page_alert.default.yml
@@ -152,6 +152,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 14

--- a/config/default/core.entity_form_display.node.landing_page.default.yml
+++ b/config/default/core.entity_form_display.node.landing_page.default.yml
@@ -294,6 +294,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 18

--- a/config/default/core.entity_form_display.node.landing_page_level_2.default.yml
+++ b/config/default/core.entity_form_display.node.landing_page_level_2.default.yml
@@ -268,6 +268,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 17

--- a/config/default/core.entity_form_display.node.multi_step_page.default.yml
+++ b/config/default/core.entity_form_display.node.multi_step_page.default.yml
@@ -391,6 +391,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 13

--- a/config/default/core.entity_form_display.node.news.default.yml
+++ b/config/default/core.entity_form_display.node.news.default.yml
@@ -333,6 +333,11 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 29

--- a/config/default/core.entity_form_display.node.site_wide_alert.default.yml
+++ b/config/default/core.entity_form_display.node.site_wide_alert.default.yml
@@ -135,6 +135,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 9


### PR DESCRIPTION
## What's Included

`simple_sitemap` adds an unpositioned pseudo-field component to entity form displays, which only gets written into config once a bundle's "Manage form display" screen is opened and saved. This had happened on UAT for most content types but was never exported/committed, causing a config diff on every deploy. Added the `simple_sitemap` component (`weight: 10, region: content`) to the 16 node form displays that were missing it, matching what UAT already has - a display-only config change, no field data affected.

## Deployment Steps

- Run `drush config:import` to pick up the updated entity form display config.