### PR TITLE
Kellett - refs #1132: fix broken media_folders taxonomy parent IDs

### DIFF
--- a/docroot/modules/custom/yukon_taxonomy/yukon_taxonomy.install
+++ b/docroot/modules/custom/yukon_taxonomy/yukon_taxonomy.install
@@ -33,6 +33,20 @@ function yukon_taxonomy_update_10000(&$sandbox) {
 }
 
 /**
+ * Fix media_folders terms with broken parent reference (tid 1 -> 0).
+ */
+function yukon_taxonomy_update_10001(&$sandbox) {
+  $database = \Drupal::database();
+  foreach (['taxonomy_term__parent', 'taxonomy_term_revision__parent'] as $table) {
+    $database->update($table)
+      ->fields(['parent_target_id' => 0])
+      ->condition('bundle', 'media_folders')
+      ->condition('parent_target_id', 1)
+      ->execute();
+  }
+}
+
+/**
  * Create taxonomy term if it doesn't exist.
  *
  * @param string $name


### PR DESCRIPTION
## What's Included

Media folders taxonomy terms were migrated from D7 with a dangling parent reference: the D7 vocabulary's true root term (tid 1) was never migrated to D10, leaving 27 of its former child terms pointing to a `parent_target_id` that doesn't exist. This included the "Media Root" term (tid 166), which was itself a child of the missing root, not a parent of the other 26 terms.

Verified against a copy of the D7 production database: aside from the missing root, every other parent/child relationship in the vocabulary (D7 and D10 term IDs match 1:1) was preserved correctly by the migration - this is a single dangling reference, not a systemic issue.

Adds `yukon_taxonomy_update_10001()`, which sets `parent_target_id` to `0` (top level) for the 27 affected `media_folders` terms, in both `taxonomy_term__parent` and `taxonomy_term_revision__parent`.

Tag #975.

## Deployment Steps

1. Deploy code
2. Run `drush updb`