### PR TITLE
Kellett - refs #1124: allow Places to have more than one record type

### DIFF
--- a/config/default/core.entity_view_display.paragraph.community_facilities.places_listing_summary.yml
+++ b/config/default/core.entity_view_display.paragraph.community_facilities.places_listing_summary.yml
@@ -1,0 +1,37 @@
+uuid: 357e9113-7eb5-478c-bcd8-b2f04cba08f5
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.places_listing_summary
+    - field.field.paragraph.community_facilities.field_about_services
+    - field.field.paragraph.community_facilities.field_assistant_manager
+    - field.field.paragraph.community_facilities.field_assistant_manager_email
+    - field.field.paragraph.community_facilities.field_assistant_manager_telephon
+    - field.field.paragraph.community_facilities.field_community_facility_type
+    - field.field.paragraph.community_facilities.field_manager
+    - field.field.paragraph.community_facilities.field_manager_email
+    - field.field.paragraph.community_facilities.field_manager_telephone
+    - paragraphs.paragraphs_type.community_facilities
+id: paragraph.community_facilities.places_listing_summary
+targetEntityType: paragraph
+bundle: community_facilities
+mode: places_listing_summary
+content:
+  field_about_services:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_assistant_manager: true
+  field_assistant_manager_email: true
+  field_assistant_manager_telephon: true
+  field_community_facility_type: true
+  field_manager: true
+  field_manager_email: true
+  field_manager_telephone: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.health_facilities.places_listing_summary.yml
+++ b/config/default/core.entity_view_display.paragraph.health_facilities.places_listing_summary.yml
@@ -1,0 +1,25 @@
+uuid: a05cb6f2-dafd-4331-bf08-dadae9e19570
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.places_listing_summary
+    - field.field.paragraph.health_facilities.field_health_facility_type
+    - field.field.paragraph.health_facilities.field_hf_services
+    - paragraphs.paragraphs_type.health_facilities
+id: paragraph.health_facilities.places_listing_summary
+targetEntityType: paragraph
+bundle: health_facilities
+mode: places_listing_summary
+content:
+  field_hf_services:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_health_facility_type: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.schools.places_listing_summary.yml
+++ b/config/default/core.entity_view_display.paragraph.schools.places_listing_summary.yml
@@ -1,0 +1,40 @@
+uuid: d925fe7e-65fc-4282-a311-1e07917dd236
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.places_listing_summary
+    - field.field.paragraph.schools.field_education_facility_type
+    - field.field.paragraph.schools.field_grades_from
+    - field.field.paragraph.schools.field_grades_to
+    - field.field.paragraph.schools.field_principal
+    - field.field.paragraph.schools.field_principal_email
+    - field.field.paragraph.schools.field_principal_telephone
+    - field.field.paragraph.schools.field_section_type
+    - field.field.paragraph.schools.field_superintendent
+    - field.field.paragraph.schools.field_superintendent_email
+    - field.field.paragraph.schools.field_superintendent_phone
+    - field.field.paragraph.schools.field_team_leader
+    - field.field.paragraph.schools.field_team_leader_email
+    - field.field.paragraph.schools.field_team_leader_phone
+    - paragraphs.paragraphs_type.schools
+id: paragraph.schools.places_listing_summary
+targetEntityType: paragraph
+bundle: schools
+mode: places_listing_summary
+content: {  }
+hidden:
+  field_education_facility_type: true
+  field_grades_from: true
+  field_grades_to: true
+  field_principal: true
+  field_principal_email: true
+  field_principal_telephone: true
+  field_section_type: true
+  field_superintendent: true
+  field_superintendent_email: true
+  field_superintendent_phone: true
+  field_team_leader: true
+  field_team_leader_email: true
+  field_team_leader_phone: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.transactional_facilities.places_listing_summary.yml
+++ b/config/default/core.entity_view_display.paragraph.transactional_facilities.places_listing_summary.yml
@@ -1,0 +1,26 @@
+uuid: d3135f47-fc53-4521-801b-4603d28c253b
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.places_listing_summary
+    - field.field.paragraph.transactional_facilities.field_tf_services
+    - field.field.paragraph.transactional_facilities.field_transactional_facility_typ
+    - paragraphs.paragraphs_type.transactional_facilities
+  module:
+    - text
+id: paragraph.transactional_facilities.places_listing_summary
+targetEntityType: paragraph
+bundle: transactional_facilities
+mode: places_listing_summary
+content:
+  field_tf_services:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_transactional_facility_typ: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_display.paragraph.waste_and_recycling_facilities.places_listing_summary.yml
+++ b/config/default/core.entity_view_display.paragraph.waste_and_recycling_facilities.places_listing_summary.yml
@@ -1,0 +1,29 @@
+uuid: 84d3a18a-d8bb-4a95-b4e7-db1857d4b89e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.places_listing_summary
+    - field.field.paragraph.waste_and_recycling_facilities.field_sanitary_facility_accepted
+    - field.field.paragraph.waste_and_recycling_facilities.field_sanitary_facility_email
+    - field.field.paragraph.waste_and_recycling_facilities.field_sanitary_facility_services
+    - field.field.paragraph.waste_and_recycling_facilities.field_sanitary_facility_type
+    - paragraphs.paragraphs_type.waste_and_recycling_facilities
+id: paragraph.waste_and_recycling_facilities.places_listing_summary
+targetEntityType: paragraph
+bundle: waste_and_recycling_facilities
+mode: places_listing_summary
+content:
+  field_sanitary_facility_services:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  field_sanitary_facility_accepted: true
+  field_sanitary_facility_email: true
+  field_sanitary_facility_type: true
+  search_api_excerpt: true

--- a/config/default/core.entity_view_mode.paragraph.places_listing_summary.yml
+++ b/config/default/core.entity_view_mode.paragraph.places_listing_summary.yml
@@ -1,0 +1,11 @@
+uuid: fe7fad75-55d5-4bc1-b572-9065f068750f
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.places_listing_summary
+label: 'Places listing summary'
+description: ''
+targetEntityType: paragraph
+cache: true

--- a/config/default/field.storage.node.field_places_record_type.yml
+++ b/config/default/field.storage.node.field_places_record_type.yml
@@ -14,7 +14,7 @@ settings:
   target_type: paragraph
 module: entity_reference_revisions
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/config/default/views.view.facilities_listing_blocks.yml
+++ b/config/default/views.view.facilities_listing_blocks.yml
@@ -266,6 +266,7 @@ display:
           admin_label: 'field_places_record_type: Paragraph'
           plugin_id: standard
           required: false
+      group_by: true
       header: {  }
       footer: {  }
       display_extenders: {  }

--- a/config/default/views.view.places_listing.yml
+++ b/config/default/views.view.places_listing.yml
@@ -3,13 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_places_record_type
     - field.storage.node.field_street_address
-    - field.storage.paragraph.field_about_services
     - node.type.directory_records_places
     - taxonomy.vocabulary.community
     - taxonomy.vocabulary.community_facilities
   module:
     - better_exposed_filters
+    - entity_reference_revisions
     - node
     - paragraphs
     - taxonomy
@@ -156,11 +157,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_about_services:
-          id: field_about_services
-          table: paragraph__field_about_services
-          field: field_about_services
-          relationship: field_places_record_type
+        field_places_record_type:
+          id: field_places_record_type
+          table: node__field_places_record_type
+          field: field_places_record_type
+          relationship: none
           group_type: group
           admin_label: ''
           plugin_id: field
@@ -193,22 +194,23 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: div
+          element_type: ''
           element_class: ''
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false
-          element_wrapper_type: '0'
+          element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings: {  }
-          group_column: value
+          click_sort_column: target_id
+          type: entity_reference_revisions_entity_view
+          settings:
+            view_mode: places_listing_summary
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -216,7 +218,7 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ''
           field_api_classes: false
       pager:
         type: full
@@ -627,6 +629,7 @@ display:
           plugin_id: standard
           required: false
       use_ajax: true
+      group_by: true
       header:
         result:
           id: result
@@ -650,8 +653,8 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_places_record_type'
         - 'config:field.storage.node.field_street_address'
-        - 'config:field.storage.paragraph.field_about_services'
   block_places_listing:
     id: block_places_listing
     display_title: Places
@@ -664,6 +667,17 @@ display:
       display_extenders:
         ajax_history:
           enable_history: true
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
       block_description: 'Places listing'
     cache_metadata:
       max-age: -1
@@ -674,5 +688,5 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.field_places_record_type'
         - 'config:field.storage.node.field_street_address'
-        - 'config:field.storage.paragraph.field_about_services'

--- a/docroot/themes/custom/yukonca_glider/templates/paragraphs/paragraph--community-facilities--places-listing-summary.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/paragraphs/paragraph--community-facilities--places-listing-summary.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Theme override to display a community facilities paragraph in the
+ * places listing summary view mode.
+ *
+ * @see paragraph--community-facilities.html.twig
+ */
+#}
+{{ content }}


### PR DESCRIPTION
## What's Included

- Raised `field_places_record_type` cardinality from 1 to unlimited, so a Places node can have more than one paragraph record type (e.g. a community facility entry and a school entry on the same place).
- Fixed `facilities_listing_blocks` and `places_listing` views to group results by the base node, so a place with multiple matching record types shows once instead of once per matching paragraph.
- `places_listing` now displays the node's `field_places_record_type` field directly (all record types render together under one row) instead of a single paragraph pulled in through a relationship. Filtering by facility-type taxonomy term still works via that relationship.
- Added a new "Places listing summary" paragraph view mode used for this display, showing only each paragraph bundle's own services/description field (`field_about_services`, `field_hf_services`, `field_tf_services`, `field_sanitary_facility_services`); `schools` has no equivalent field so renders nothing for this mode.
- Added a paragraph template override (`paragraph--community-facilities--places-listing-summary.html.twig`) so this view mode isn't affected by the shared community-facilities template's hardcoded manager/assistant-manager blocks.

Tag #975 

## Deployment Steps

- Deploy code
- `drush cim` to import configuration
- Clear cache