### PR TITLE
Kellett - refs #1112: Make revision log field mandatory

### DIFF
--- a/docroot/modules/custom/yukon_base/yukon_base.module
+++ b/docroot/modules/custom/yukon_base/yukon_base.module
@@ -5,10 +5,12 @@
  * Main module file.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_form_alter().
  */
-function yukon_base_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+function yukon_base_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (!in_array($form_id, ['node_multi_step_page_form', 'node_multi_step_page_edit_form'])) {
     return;
   }
@@ -33,6 +35,15 @@ function yukon_base_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $for
         $form['field_paragraphs']['widget'][$key]['top']['actions']['dropdown_actions']['duplicate_button']['#access'] = FALSE;
       }
     }
+  }
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for node_form.
+ */
+function yukon_base_form_node_form_alter(&$form, FormStateInterface $form_state) {
+  if (isset($form['revision_log']['widget'][0]['value'])) {
+    $form['revision_log']['widget'][0]['value']['#required'] = TRUE;
   }
 }
 


### PR DESCRIPTION
## What's Included

Custom form alter that makes revision log message required for all users.

Resolves #1112

## Deployment Steps

1. Deploy Code
2. Rebuild cache

## How to Test

1. Create or edit content of any type
2. See that there is a required indicator on the revision log message field
3. See that it won't allow you to save without entering a revision log message