### PR TITLE
Kellett - refs #985: General search - Form filter should include online-form pages

### DIFF
--- a/config/default/language/fr/views.view.search.yml
+++ b/config/default/language/fr/views.view.search.yml
@@ -11,8 +11,6 @@ display:
           expose:
             placeholder: Mots-clés
         type:
-          expose:
-            description: ''
           group_info:
             label: Par
             group_items:
@@ -26,13 +24,11 @@ display:
                 title: Lieux
               6:
                 title: Blogues
-        field_document_type:
           expose:
             description: ''
-          group_info:
-            group_items:
-              1:
-                title: Formulaires
+        field_form_type:
+          expose:
+            label: Formulaires
         field_department_term:
           expose:
             label: Ministère

--- a/config/default/search_api.index.global.yml
+++ b/config/default/search_api.index.global.yml
@@ -156,6 +156,15 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_fax
+  field_form_type:
+    label: 'Form (aggregated)'
+    property_path: aggregated_field
+    type: boolean
+    configuration:
+      type: max
+      fields:
+        - 'entity:node/field_document_type'
+        - 'entity:node/field_this_is_an_online_form'
   field_main_telephone:
     label: 'Main telephone'
     datasource_id: 'entity:node'
@@ -312,11 +321,11 @@ processor_settings:
     title: true
     alt: true
     tags:
-      b: 2
-      h1: 5
-      h2: 3
-      h3: 2
-      strong: 2
+      b: 2.0
+      h1: 5.0
+      h2: 3.0
+      h3: 2.0
+      strong: 2.0
   language_with_fallback: {  }
   rendered_item: {  }
   solr_boost_more_recent:

--- a/config/default/views.view.search.yml
+++ b/config/default/views.view.search.yml
@@ -337,7 +337,7 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
           text_input_required: 'Please enter your search terms.'
-          text_input_required_format: basic_html
+          text_input_required_format: plain_text
           bef:
             general:
               autosubmit: false
@@ -350,32 +350,46 @@ display:
               secondary_open: false
               reset_button_always_show: false
             filter:
-              search_api_fulltext:
-                plugin_id: default
-                advanced:
-                  placeholder_text: ''
-                  rewrite:
-                    filter_rewrite_values: ''
-                  collapsible: false
-                  is_secondary: false
               type:
                 plugin_id: bef
                 advanced:
                   sort_options: false
                   rewrite:
                     filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
                   collapsible: false
+                  collapsible_disable_automatic_open: false
                   is_secondary: false
                 select_all_none: false
                 select_all_none_nested: false
                 display_inline: false
-              field_document_type:
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
+              search_api_fulltext:
                 plugin_id: default
+                advanced:
+                  placeholder_text: ''
+                  rewrite:
+                    filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
+                  collapsible: false
+                  collapsible_disable_automatic_open: false
+                  is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: false
+              field_form_type:
+                plugin_id: bef_single
                 advanced:
                   sort_options: false
                   rewrite:
                     filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
                   collapsible: false
+                  collapsible_disable_automatic_open: false
                   is_secondary: false
               field_department_term:
                 plugin_id: default
@@ -383,8 +397,14 @@ display:
                   sort_options: false
                   rewrite:
                     filter_rewrite_values: ''
+                    filter_rewrite_values_key: false
                   collapsible: false
+                  collapsible_disable_automatic_open: false
                   is_secondary: false
+                options_show_only_used: false
+                options_show_only_used_filtered: false
+                options_hide_when_empty: false
+                options_show_items_count: 0
       access:
         type: none
         options: {  }
@@ -434,6 +454,84 @@ display:
           exposed: false
       arguments: {  }
       filters:
+        type:
+          id: type
+          table: search_api_index_global
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_options
+          operator: or
+          value: {  }
+          group: 2
+          exposed: true
+          expose:
+            operator_id: type_op
+            label: 'Content type'
+            description: null
+            use_operator: false
+            operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: type
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: true
+          group_info:
+            label: 'Show only'
+            description: ''
+            identifier: type
+            optional: true
+            widget: select
+            multiple: true
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items:
+              1:
+                title: 'Web pages'
+                operator: or
+                value:
+                  basic_page: basic_page
+                  campaign_page: campaign_page
+                  campground_directory_record: campground_directory_record
+                  department: department
+                  engagement: engagement
+                  homepage: homepage
+                  landing_page: landing_page
+                  landing_page_level_2: landing_page_level_2
+                  multi_step_page: multi_step_page
+              2:
+                title: Documents
+                operator: or
+                value:
+                  documents: documents
+              3:
+                title: News
+                operator: or
+                value:
+                  news: news
+              4:
+                title: Events
+                operator: or
+                value:
+                  event: event
+              5:
+                title: Places
+                operator: or
+                value:
+                  directory_records_places: directory_records_places
+              6:
+                title: Blogs
+                operator: or
+                value:
+                  blog: blog
+          reduce_duplicates: false
         status:
           id: status
           table: search_api_index_global
@@ -529,130 +627,60 @@ display:
           parse_mode: terms
           min_length: null
           fields: {  }
-        type:
-          id: type
+        field_form_type:
+          id: field_form_type
           table: search_api_index_global
-          field: type
+          field: field_form_type
           relationship: none
           group_type: group
           admin_label: ''
-          plugin_id: search_api_options
-          operator: or
-          value: {  }
+          plugin_id: search_api_string
+          operator: '='
+          value: All
           group: 1
           exposed: true
           expose:
-            operator_id: type_op
-            label: 'Content type'
-            description: null
-            use_operator: false
-            operator: type_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: true
-          group_info:
-            label: 'Show only'
+            operator_id: field_form_type_op
+            label: Form
             description: ''
-            identifier: type
-            optional: true
-            widget: select
-            multiple: true
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items:
-              1:
-                title: 'Web pages'
-                operator: or
-                value:
-                  basic_page: basic_page
-                  campaign_page: campaign_page
-                  campground_directory_record: campground_directory_record
-                  department: department
-                  engagement: engagement
-                  homepage: homepage
-                  landing_page: landing_page
-                  landing_page_level_2: landing_page_level_2
-                  multi_step_page: multi_step_page
-              2:
-                title: Documents
-                operator: or
-                value:
-                  documents: documents
-              3:
-                title: News
-                operator: or
-                value:
-                  news: news
-              4:
-                title: Events
-                operator: or
-                value:
-                  event: event
-              5:
-                title: Places
-                operator: or
-                value:
-                  directory_records_places: directory_records_places
-              6:
-                title: Blogs
-                operator: or
-                value:
-                  blog: blog
-          reduce_duplicates: false
-        field_document_type:
-          id: field_document_type
-          table: search_api_index_global
-          field: field_document_type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: search_api_options
-          operator: or
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: field_document_type_op
-            label: 'Document Type'
-            description: null
             use_operator: false
-            operator: field_document_type_op
+            operator: field_form_type_op
             operator_limit_selection: false
             operator_list: {  }
-            identifier: field_document_type
+            identifier: field_form_type
             required: false
             remember: false
-            multiple: true
+            multiple: false
             remember_roles:
               authenticated: authenticated
-            reduce: false
-          is_grouped: true
+              anonymous: '0'
+              administrator: '0'
+              writer: '0'
+              editor: '0'
+              publisher: '0'
+              translator: '0'
+              team_administrator: '0'
+              site_administrator: '0'
+              dis_blog: '0'
+              _webform_manager: '0'
+              author_in_page_alerts: '0'
+              blog_author: '0'
+              author_site_wide_alerts: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
           group_info:
             label: ''
             description: ''
-            identifier: document_type
+            identifier: ''
             optional: true
             widget: select
-            multiple: true
+            multiple: false
             remember: false
             default_group: All
             default_group_multiple: {  }
-            group_items:
-              1:
-                title: Form
-                operator: or
-                value:
-                  - '0'
-                  - '1'
-          reduce_duplicates: false
+            group_items: {  }
         field_department_term:
           id: field_department_term
           table: search_api_index_global
@@ -754,6 +782,7 @@ display:
         operator: AND
         groups:
           1: AND
+          2: OR
       style:
         type: default
         options:
@@ -797,7 +826,10 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.global'
+        - 'search_api_list:global'
   page_1:
     id: page_1
     display_title: 'Global search'
@@ -808,6 +840,17 @@ display:
       exposed_block: true
       display_extenders:
         ajax_history: {  }
+        matomo:
+          enabled: false
+          keyword_gets: ''
+          keyword_behavior: first
+          keyword_concat_separator: ' '
+          category_behavior: none
+          category_gets: ''
+          category_concat_separator: ' '
+          category_fallback: ''
+          category_facets: {  }
+          category_facets_concat_separator: ', '
       path: search
     cache_metadata:
       max-age: -1
@@ -816,4 +859,7 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-      tags: {  }
+        - 'user.node_grants:view'
+      tags:
+        - 'config:search_api.index.global'
+        - 'search_api_list:global'

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/filters/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/filters/dist/css/styles.min.css
@@ -1308,7 +1308,7 @@
   overflow-y: auto;
 }
 
-.form .form-wrapper .fieldset-legend, .form .js-form-item .form-type-checkbox label, .form .js-form-item label {
+.form .form-wrapper .fieldset-legend, .form .js-form-item.form-type-checkbox label, .form .js-form-item label {
   display: block;
   font-weight: 400;
   --tw-text-opacity: 1;
@@ -1344,16 +1344,16 @@ h2.title {
   padding-left: 12px;
   padding-right: 12px;
 }
-.form .js-form-item .form-type-checkbox input {
+.form .js-form-item.form-type-checkbox input {
   position: absolute;
   left: 0px;
   margin-top: 0.25rem;
 }
-.form .js-form-item .form-type-checkbox label {
+.form .js-form-item.form-type-checkbox label {
   margin-bottom: 0px;
   padding-left: 1.25rem;
 }
-.form .js-form-item .form-type-checkbox legend:has(span:empty) {
+.form .js-form-item.form-type-checkbox legend:has(span:empty) {
   display: none;
 }
 .form .form-submit {

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/filters/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/filters/scss/styles.scss
@@ -25,7 +25,7 @@ h2.title {
       @apply h-[37px] py-[6px] px-[12px] w-full;
     }
 
-    .form-type-checkbox {
+    &.form-type-checkbox {
       input {
           @apply absolute left-0 mt-1;
       }

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/header/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/header/dist/css/styles.min.css
@@ -105,10 +105,7 @@
   --tw-bg-opacity: 1;
   background-color: rgb(243 178 41 / var(--tw-bg-opacity));
 }
-.header--main .header-search form .fieldgroup {
-  display: none;
-}
-.header--main .header-search form .form-item-department {
+.header--main .header-search form .form > *:not(.form-type-textfield):not(.form-actions) {
   display: none;
 }
 /*# sourceMappingURL=styles.min.css.map */

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/header/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/header/scss/styles.scss
@@ -78,14 +78,10 @@
             @apply bg-yellow-dark border-yellow-dark;
           }
         }
-      }
 
-      .fieldgroup {
-        @apply hidden;
-      }
-
-      .form-item-department {
-        @apply hidden;
+        > *:not(.form-type-textfield):not(.form-actions) {
+          @apply hidden;
+        }
       }
     }
   }


### PR DESCRIPTION
## What's Included

The "Form" filter on general search (`/search`) previously only matched the `field_document_type` value on the Documents content type, so pages that are themselves online forms (`field_this_is_an_online_form`, on Basic page / Multi-step page) never showed up when filtering by "Form" - e.g. searching "register for school bus" with the Form filter checked never surfaced the actual online registration page.

- Added a new `field_form_type` field to the global search index (`config/default/search_api.index.global.yml`), aggregating `field_document_type` and `field_this_is_an_online_form` (both effectively 0/1-valued) via the `max` aggregation, and typed as `boolean` so it correctly renders as a real single checkbox in the exposed filter (rather than a select or free-text widget).
- Updated the "Form" exposed filter on the search view (`config/default/views.view.search.yml`) to use the new aggregated field.
- Fixed an unrelated, pre-existing bug found while testing this: the "Content type" exposed filter ANDed together multiple selected content types (e.g. selecting "Web pages" and "Documents" always returned zero results, since a node can't be both at once). Moved it into its own filter group with an OR conjunction so multiple selected content types are ORed together, while still being ANDed against the other filters (Form, keywords) as expected.
- Fixed theme CSS (`yukonca_glider`) that assumed grouped checkboxes were always nested inside a wrapping `.js-form-item`, which isn't the case for a standalone boolean checkbox - the "Form" filter's label was rendering below the checkbox instead of beside it. Also fixed the header search form's field-hiding CSS, which hid fields by an explicit class list rather than generically, so the new "Form" checkbox was leaking into the header search form (which should only ever show the keywords field).

## Deployment Steps

- Run `drush config:import` to pick up the updated `search_api.index.global`, `views.view.search`, and French translation override config.
- Full reindex required (`drush search-api:clear && drush search-api:index`, or equivalent) so the new `field_form_type` field is populated on all indexed content.
- Theme CSS is precompiled and included in this PR (`dist/css` files) - no separate build step needed on deploy.