### PR TITLE
Kellett - refs #1137: Make Translation status field only editable by translation team

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -56,6 +56,7 @@ module:
   fences: 0
   field: 0
   field_group: 0
+  field_permissions: 0
   field_ui: 0
   file: 0
   filefield_paths: 0

--- a/config/default/field.storage.node.field_translation_status.yml
+++ b/config/default/field.storage.node.field_translation_status.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - options
+third_party_settings:
+  field_permissions:
+    permission_type: custom
 id: node.field_translation_status
 field_name: field_translation_status
 entity_type: node

--- a/config/default/user.role._webform_manager.yml
+++ b/config/default/user.role._webform_manager.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - webform
 id: _webform_manager
 label: '+Webform Manager'
@@ -31,4 +32,6 @@ permissions:
   - 'edit webform twig'
   - 'edit webform variants'
   - 'view any webform submission'
+  - 'view field_translation_status'
+  - 'view own field_translation_status'
   - 'view own webform submission'

--- a/config/default/user.role.author_in_page_alerts.yml
+++ b/config/default/user.role.author_in_page_alerts.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - content_moderation
     - contextual
+    - field_permissions
     - filter
     - node
     - path
@@ -42,6 +43,8 @@ permissions:
   - 'use text format full_html'
   - 'use workbench access'
   - 'view any unpublished content'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view the administration theme'
   - 'view workbench access information'

--- a/config/default/user.role.author_site_wide_alerts.yml
+++ b/config/default/user.role.author_site_wide_alerts.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - content_moderation
     - contextual
+    - field_permissions
     - filter
     - node
     - path
@@ -44,6 +45,8 @@ permissions:
   - 'use text format full_html'
   - 'use workbench access'
   - 'view any unpublished content'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view the administration theme'
   - 'view workbench access information'

--- a/config/default/user.role.blog_author.yml
+++ b/config/default/user.role.blog_author.yml
@@ -10,6 +10,7 @@ dependencies:
     - content_moderation
     - content_translation
     - contextual
+    - field_permissions
     - filter
     - media
     - node
@@ -50,7 +51,9 @@ permissions:
   - 'use workbench access'
   - 'view all revisions'
   - 'view all revisions'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view the administration theme'
   - 'view workbench access information'

--- a/config/default/user.role.dis_blog.yml
+++ b/config/default/user.role.dis_blog.yml
@@ -6,6 +6,7 @@ dependencies:
     - filter.format.full_html
   module:
     - content_moderation
+    - field_permissions
     - filter
 id: dis_blog
 label: 'DIS blog'
@@ -13,4 +14,6 @@ weight: 10
 is_admin: null
 permissions:
   - 'use text format full_html'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'

--- a/config/default/user.role.editor.yml
+++ b/config/default/user.role.editor.yml
@@ -32,6 +32,7 @@ dependencies:
     - content_moderation
     - contextual
     - entity_browser
+    - field_permissions
     - filter
     - linkchecker
     - media
@@ -149,7 +150,9 @@ permissions:
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view basic_page revisions'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'

--- a/config/default/user.role.publisher.yml
+++ b/config/default/user.role.publisher.yml
@@ -28,6 +28,7 @@ dependencies:
   module:
     - content_moderation
     - contextual
+    - field_permissions
     - file
     - filter
     - linkchecker
@@ -177,8 +178,10 @@ permissions:
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view basic_page revisions'
+  - 'view field_translation_status'
   - 'view latest version'
   - 'view media'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'

--- a/config/default/user.role.site_administrator.yml
+++ b/config/default/user.role.site_administrator.yml
@@ -56,6 +56,7 @@ dependencies:
     - content_moderation
     - content_translation
     - contextual
+    - field_permissions
     - field_ui
     - file
     - filter
@@ -155,6 +156,7 @@ permissions:
   - 'create documents content'
   - 'create engagement content'
   - 'create event content'
+  - 'create field_translation_status'
   - 'create homepage content'
   - 'create icon media'
   - 'create image media'
@@ -250,6 +252,7 @@ permissions:
   - 'edit any topics_page content'
   - 'edit any video media'
   - 'edit any webform submission'
+  - 'edit field_translation_status'
   - 'edit linkchecker link settings'
   - 'edit own audio media'
   - 'edit own blog content'
@@ -262,6 +265,7 @@ permissions:
   - 'edit own documents content'
   - 'edit own engagement content'
   - 'edit own event content'
+  - 'edit own field_translation_status'
   - 'edit own homepage content'
   - 'edit own icon media'
   - 'edit own image media'
@@ -353,7 +357,9 @@ permissions:
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view basic_page revisions'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view own webform submission'

--- a/config/default/user.role.team_administrator.yml
+++ b/config/default/user.role.team_administrator.yml
@@ -8,6 +8,7 @@ dependencies:
     - taxonomy.vocabulary.category
   module:
     - contextual
+    - field_permissions
     - filter
     - linkchecker
     - node
@@ -40,6 +41,8 @@ permissions:
   - 'edit terms in category'
   - 'use text format full_html'
   - 'use workbench access'
+  - 'view field_translation_status'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view the administration theme'
   - 'view workbench access information'

--- a/config/default/user.role.translator.yml
+++ b/config/default/user.role.translator.yml
@@ -53,6 +53,7 @@ dependencies:
     - content_moderation
     - content_translation
     - contextual
+    - field_permissions
     - file
     - filter
     - linkchecker
@@ -101,6 +102,7 @@ permissions:
   - 'create documents content'
   - 'create engagement content'
   - 'create event content'
+  - 'create field_translation_status'
   - 'create homepage content'
   - 'create icon media'
   - 'create image media'
@@ -188,6 +190,7 @@ permissions:
   - 'edit any site_wide_alert content'
   - 'edit any topics_page content'
   - 'edit any video media'
+  - 'edit field_translation_status'
   - 'edit own audio media'
   - 'edit own basic_page content'
   - 'edit own blog content'
@@ -199,6 +202,7 @@ permissions:
   - 'edit own documents content'
   - 'edit own engagement content'
   - 'edit own event content'
+  - 'edit own field_translation_status'
   - 'edit own homepage content'
   - 'edit own icon media'
   - 'edit own image media'
@@ -287,8 +291,10 @@ permissions:
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view basic_page revisions'
+  - 'view field_translation_status'
   - 'view latest version'
   - 'view media'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'

--- a/config/default/user.role.writer.yml
+++ b/config/default/user.role.writer.yml
@@ -26,6 +26,7 @@ dependencies:
   module:
     - content_moderation
     - contextual
+    - field_permissions
     - filter
     - linkchecker
     - media
@@ -121,7 +122,9 @@ permissions:
   - 'view all revisions'
   - 'view any unpublished content'
   - 'view basic_page revisions'
+  - 'view field_translation_status'
   - 'view latest version'
+  - 'view own field_translation_status'
   - 'view own unpublished content'
   - 'view own unpublished media'
   - 'view the administration theme'


### PR DESCRIPTION
## What's Included

The "Translation status" field (`field_translation_status`) was editable by anyone with edit access to a content type, with no way to restrict it to just the translation team.

- Enabled the `field_permissions` module (already a composer dependency, previously unused/disabled).
- Set `field_translation_status`'s permission type to `custom`, restricting create/edit access to the `translator` and `site_administrator` roles.
- All other content-editing roles (editor, publisher, writer, blog author, team administrator, webform manager, in-page alert author, site-wide alert author) can still view the field but no longer create or edit it.

## Deployment Steps

- Run `drush config:import` to enable `field_permissions` and pick up the updated field and role permission config.