### PR TITLE
Kellett - refs #1125: remove home page carousel auto shuffle

### DIFF
--- a/docroot/themes/custom/yukonca_glider/templates/field/field--node--field-image-gallery.html.twig
+++ b/docroot/themes/custom/yukonca_glider/templates/field/field--node--field-image-gallery.html.twig
@@ -56,7 +56,7 @@
   ]
 %}
 {# TODO: Move this structure to the ui_pattern. #}
-<div id="image-gallery" class="featured-info carousel slide" data-bs-ride="carousel">
+<div id="image-gallery" class="featured-info carousel slide">
 	<div {{ attributes.addClass(classes) }}>
     {% for item in items %}
       {% set carousel_item = ['carousel-item', loop.first ? 'active'] %}


### PR DESCRIPTION
## What's Included

Removes the `data-bs-ride="carousel"` attribute from the home page image gallery carousel template, which was triggering automatic auto-rotation of the carousel.

## Deployment Steps

1. Deploy code
2. Rebuild cache