### PR TITLE
Kellett - refs #964: fix accordion display in visual inline revision diff

### DIFF
--- a/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.module
+++ b/docroot/modules/custom/yukon_w3_custom/yukon_w3_custom.module
@@ -138,9 +138,11 @@ function yukon_w3_custom_page_attachments(array &$page) {
       $chart_data = [];
       foreach ($items as $item) {
         $p = Paragraph::load($item['target_id']);
-        $chart = Paragraph::load($p->field_paragraphs->target_id);
-        if (!empty($chart)) {
-          $chart_data[$chart->id()] = $chart->field_chart_data->value;
+        if (!empty($p->field_paragraphs->target_id)) {
+          $chart = Paragraph::load($p->field_paragraphs->target_id);
+          if (!empty($chart)) {
+            $chart_data[$chart->id()] = $chart->field_chart_data->value;
+          }
         }
 
       }

--- a/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/dist/css/styles.min.css
@@ -3689,6 +3689,10 @@ h1#heading{
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
+.diff-responsive-table-wrapper .yukon-accordion__buttons{
+  display: none;
+}
+
 .accordion .accordion-item:not(.inner){
   margin-top: 5px;
   border-radius: 0.25rem;

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/accordion/dist/css/styles.min.css
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/accordion/dist/css/styles.min.css
@@ -1,2 +1,7 @@
-/* Add your code here */
+.diff-responsive-table-wrapper .collapse {
+  display: block !important;
+}
+.diff-responsive-table-wrapper [data-bs-toggle=collapse] {
+  display: none;
+}
 /*# sourceMappingURL=styles.min.css.map */

--- a/docroot/themes/custom/yukonca_glider/patterns/organisms/accordion/scss/styles.scss
+++ b/docroot/themes/custom/yukonca_glider/patterns/organisms/accordion/scss/styles.scss
@@ -1,1 +1,15 @@
-/* Add your code here */
+// Visual Inline diff view: collapse targets have no IDs (stripped by diff
+// module), so Bootstrap's collapse JS can't expand them. Force any
+// Bootstrap collapse-based content visible and hide the (non-functional)
+// toggle buttons. Targets the generic Bootstrap collapse API rather than
+// accordion-specific classes so it also covers any future component built
+// on it.
+.diff-responsive-table-wrapper {
+  .collapse {
+    display: block !important;
+  }
+
+  [data-bs-toggle="collapse"] {
+    @apply hidden;
+  }
+}

--- a/docroot/themes/custom/yukonca_glider/src/sass/base/partials/_accordion.scss
+++ b/docroot/themes/custom/yukonca_glider/src/sass/base/partials/_accordion.scss
@@ -25,6 +25,13 @@
 	}
 }
 
+// Visual Inline diff view: all accordion panes are forced open (see
+// organisms/accordion/scss/styles.scss), so the expand/collapse-all
+// controls have nothing to do and shouldn't be shown.
+.diff-responsive-table-wrapper .yukon-accordion__buttons {
+	@apply hidden;
+}
+
 .accordion {
 	.accordion-item {
 		&:not(.inner) {


### PR DESCRIPTION
### What's Included

Fixes #964

Follow-up to #1088, which fixed the same issue for tabs. The diff module strips ID attributes needed by Bootstrap's collapse JS, so accordion panes stayed collapsed in the visual inline comparison view, hiding content from translators. This adds the equivalent CSS override for accordions: panes are forced open and the individual toggle buttons plus the expand/collapse-all controls are hidden when rendered inside the diff view.

Also includes a fix in `yukon_w3_custom_page_attachments()`: it was unconditionally loading a nested chart paragraph for every collapsible item, but that nested paragraph is optional. On items without one, this loaded a NULL ID, which is normally silent but is asserted against in debug/dev environments — fixed with a simple empty check.

### Deployment Steps

- Deploy code
- Rebuild caches